### PR TITLE
Fixed command line arguments to enfuse version 4.2 (latest from 2016)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+0.7.6 (02.11.2010)
+
+  * Minor UI update (now requires gtk 3.0+)
+  * Fixed gtk3 deprecation warnings
+  * Fixed enfuse invocation for newer versions of enfuse:
+    * Prevents colored pixel artifacts by additional colorspace parameter
+    * Removed deprecated cache parameters
+    * Adjusted mu / sigma exposure parameters to new parameters
+  * Improved align_image_stack invocation with alignment of more degrees of freedom
+  * Improved cli output and verboseness for debugging and pure information
+  * Minor bugfixes and code refactoring
+  * Fixed activation of align features
+  * Clean up language mix in code and folder usage (WIP)
+
 0.7.5 (07.09.2016)
 
   * Added default directory for open and save dialogs in config file (~/.config/mfusion/mfusion.cfg)

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -659,8 +659,6 @@ class Interface:
         settings["fuse_settings"]["saturation-weight"][1]   = self.spinbuttonsat.get_value()
         if self.check_pyramidelevel.get_active():
             settings["fuse_settings"]["levels"][1]          = self.spinbuttonlevel.get_value_as_int()
-        else:
-            settings["fuse_settings"]["levels"][1]          = 0
         if self.check_hardmask.get_active():
             settings["fuse_settings"]["hard-mask"][1] = True
             settings["fuse_settings"]["soft-mask"][1] = False

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -140,7 +140,7 @@ settings = {
         # force hard blend masks and no averaging on finest scale
         "hard-mask"             : ["--hard-mask",               False],
         # apply gray-scale PROJECTOR in exposure or contrast weighing, where PROJECTOR is one of
-        # 0: "anti-value", 1: "average", 2: "l-star", 3: "lightness", 4: "luminance", 5: "pl-star", 6: "value"
+        # 0: "average", 1: "l-star", 2: "lightness", 3: "value", 4: "luminance", 5: "pl-star"
         "gray-projector"        : ["--gray-projector",          1],
         # set window SIZE for local-contrast analysis     
         "contrast-window-size"  : ["--contrast-window-size",    3],

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -798,18 +798,33 @@ class Interface:
         settings["default_folder"] = path
         for file in self.files:
             if re.search('\\.jpg$|\\.jpeg$|\\.tiff$|\\.tif$', file, flags=re.IGNORECASE):
-                pb = GdkPixbuf.Pixbuf.new_from_file(file)
-                im = self.pixbuf2Image(pb)
-                self.size = im.size
-                # self.tags2 = Gui.get_exif(file)
-                if not self.tags2:
-                    self.tags2 = ''
-                self.tooltip = ("\n" + _("<b>Filename:</b> ") + os.path.basename(file) + "\n"+_("<b>Resolution:</b> ") + str(str(self.size[0]) + "x" + str(self.size[1])) + "\n" + self.tags2)
-                self.liststoreimport.append([1, file, GdkPixbuf.Pixbuf.new_from_file_at_size(file, 128, 128), self.tooltip])
+                try:
+                    pb = GdkPixbuf.Pixbuf.new_from_file(file)
+                    im = self.pixbuf2Image(pb)
+                    self.size = im.size
+                    # self.tags2 = Gui.get_exif(file)
+                    if not self.tags2:
+                        self.tags2 = ''
+                    self.tooltip = ("\n" + _("<b>Filename:</b> ") + os.path.basename(file) + "\n"+_("<b>Resolution:</b> ") + str(str(self.size[0]) + "x" + str(self.size[1])) + "\n" + self.tags2)
+                    self.liststoreimport.append([1, file, GdkPixbuf.Pixbuf.new_from_file_at_size(file, 128, 128), self.tooltip])
+                except GLib.GError:
+                    message = file
+                    meta = GExiv2.Metadata(file)
+                    bps = int(meta.try_get_tag_string('Exif.Image.BitsPerSample')[0:2])
+                    sf = int(meta.try_get_tag_string('Exif.Image.SampleFormat')[0:2])
+                    if bps == None or sf == None:
+                        message += " [format:Unknown] not supported"
+                    elif sf > 1:
+                        message += " [format:float" + str(bps) + "] not supported"
+                    elif bps > 16:
+                        message += " [format:int" + str(bps) + "] not supported"
+                    else:
+                        message += " [format:Unknown] not supported"
+                    self.badfiles.append(message)
             else:
                 self.badfiles.append(file)
         if len(self.badfiles)>0:
-            message = _("Only JPEG and TIFF files are allowed.\n\nCannot open:\n")
+            message = _("Only JPEG and TIFF (int8, int16) files are allowed.\n\nCannot open:\n")
             for itz in self.badfiles:
                 message += itz + "\n"
             Gui.messageinthebottle(message)

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -570,10 +570,6 @@ class Interface:
         files = [os.path.normpath(x.lstrip("file:")) for x in files]
         # get rid of 'file:' and replace %xx escapes
         files = [urllib.parse.unquote(x) for x in files]
-        (path, file) = os.path.split(files[0])
-        (filename, ext) = os.path.splitext(file)
-        settings["default_file"] = filename+"-fused"+ext
-        settings["default_folder"] = path
         self.put_files_to_the_list(files)
         
     def add(self, widget):
@@ -793,6 +789,11 @@ class Interface:
         self.files = files
         self.tags2 = ''
         self.badfiles = []
+        # TODO: check if resolution of files match!
+        (path, file) = os.path.split(files[0])
+        (filename, ext) = os.path.splitext(file)
+        settings["default_file"] = filename+"-fused"+ext
+        settings["default_folder"] = path
         for file in self.files:
             if re.search('\\.jpg$|\\.jpeg$|\\.tiff$|\\.tif$', file, flags=re.IGNORECASE):
                 pb = GdkPixbuf.Pixbuf.new_from_file(file)
@@ -841,10 +842,6 @@ class OpenFiles_Dialog:
             self.files = self.file_dialog.get_filenames()
             self.tags2 = ''
             self.badfiles = []
-            # TODO: check if resolution of files match!
-            (path, file) = os.path.split(self.files[0])
-            (filename, ext) = os.path.splitext(file)
-            settings["default_file"] = filename+"-fused"+ext
             Gui.put_files_to_the_list(self.files)
 
         settings["default_folder"] = self.file_dialog.get_current_folder()

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -34,8 +34,9 @@ try:
     require_version('GExiv2', '0.10')
     from gi.repository import Gdk, Gtk, GObject, GdkPixbuf, GExiv2
 
-except:    
+except Exception as e:    
     print('An error occured. Python or one of its sub modules is absent...\nIt would be wise to check your python installation.')
+    print(e)
     sys.exit(1)    
 
 try:

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -47,13 +47,11 @@ if os.path.exists('/usr/share/mfusion/ui/ui.xml') \
     and os.path.exists('/usr/share/mfusion/ui/progress.xml') \
     and os.path.exists('/usr/share/pixmaps/macrofusion.png') \
     and os.path.exists('/usr/share/mfusion/images/logoSplash.png'):
-    # print ("System wide install!")
     DIR = '/usr/share/locale/'
     IMG = '/usr/share/pixmaps/'
     IMG2 = '/usr/share/mfusion/images/'
     UI = '/usr/share/mfusion/ui/'
 elif os.path.exists(sys.path[0] + "/ui/ui.xml"):
-    # print ("Local run!")
     DIR = sys.path[0] + '/locale/'
     IMG = sys.path[0] + '/images/'
     IMG2 = sys.path[0] + '/images/'
@@ -407,16 +405,10 @@ class Interface:
 
         self.check_pnt = self.gui.get_object("check_pnt")
         self.spinbuttonpnt = self.gui.get_object("spinbuttonpnt")
-        #self.ajus_corrthres = Gtk.Adjustment(value=0, lower=0, upper=1, step_increment=0.1, page_increment=0.1, page_size=0)
-        #self.spinbuttoncorrthres.set_adjustment(self.ajus_corrthres)
-        #self.spinbuttoncorrthres.set_digits(1)
         self.spinbuttonpnt.set_value(int(settings["align_settings"]["num_ctrl_pnt"][1]))
 
         self.check_pntthr = self.gui.get_object("check_pntthr")
         self.spinbuttonpntthr = self.gui.get_object("spinbuttonpntthr")
-        #self.ajus_corrthres = Gtk.Adjustment(value=0, lower=0, upper=1, step_increment=0.1, page_increment=0.1, page_size=0)
-        #self.spinbuttoncorrthres.set_adjustment(self.ajus_corrthres)
-        #self.spinbuttoncorrthres.set_digits(1)
         self.spinbuttonpntthr.set_value(int(settings["align_settings"]["ctrl_pnt_thr"][1]))
 
         self.spinbuttonlargeurprev = self.gui.get_object("spinbuttonlargeurprev")
@@ -546,9 +538,6 @@ class Interface:
             self.checkbuttonalignfiles.set_sensitive(False)
 
     def exit_app(self, action):
-        # cancel = self.autosave_image()
-        # if cancel:
-        #    return True
         self.stop_now = True
         self.closing_app = True
         self.save_settings()
@@ -579,12 +568,6 @@ class Interface:
         self.colonneselect.pack_start(self.select, True)                        #on met le cellrender dans la colonne
         self.colonneselect.add_attribute(self.select, 'active', 0)              #on met les boutons actifs par défaut
         
-        # self.colonneimages = Gtk.TreeViewColumn(_('Image'))                        #deuxieme colonne, titre 'Image'
-        # self.listimages.append_column(self.colonneimages)                      #on rajoute la colonne dans le treeview
-        # self.cell = Gtk.CellRendererText()                                      #Ce sera des cellules de texte
-        # self.colonneimages.pack_start(self.cell, True)                          #que l'on met dans la colonne
-        # self.colonneimages.add_attribute(self.cell, 'text', 1)                  #et on specifie que c'est du texte simple
-       
         self.colonneimages2 = Gtk.TreeViewColumn(_("Thumbnail"))                        #deuxieme colonne, titre 'Image'
         self.listimages.append_column(self.colonneimages2)                      #on rajoute la colonne dans le treeview
         self.cell2 = Gtk.CellRendererPixbuf()                                      #Ce sera des cellules de texte
@@ -824,7 +807,6 @@ class Interface:
     def save_settings(self):
         conf = configparser.ConfigParser()
         conf.add_section('prefs')
-        # conf.set('prefs', 'w', self.spinbuttonEdge.get_value_as_int())
         conf.set('prefs', 'pwidth', str(self.spinbuttonlargeurprev.get_value_as_int()))
         conf.set('prefs', 'pheight', str(self.spinbuttonhauteurprev.get_value_as_int()))
         conf.set('prefs', 'outsize', str(self.checkbuttonfinalsize.get_active()))
@@ -861,7 +843,6 @@ class Interface:
                     pb = GdkPixbuf.Pixbuf.new_from_file(file)
                     im = self.pixbuf2Image(pb)
                     self.size = im.size
-                    # self.tags2 = Gui.get_exif(file)
                     if not self.tags2:
                         self.tags2 = ''
                     self.tooltip = ("\n" + _("<b>Filename:</b> ") + os.path.basename(file) + "\n"+_("<b>Resolution:</b> ") + str(str(self.size[0]) + "x" + str(self.size[1])) + "\n" + self.tags2)
@@ -1059,7 +1040,6 @@ class Thread_Fusion(threading.Thread):
         self.img_list_aligned = img_list_aligned
         self.command_fuse  = [data.get_all_settings["enfuser"], "-o", self.name] + data.get_enfuse_options + self.img_list_aligned
         self.command_align = ["align_image_stack", '-a', os.path.join(settings["preview_folder"], settings["align_prefix"])] + data.get_align_options() + self.img_list
-        #sprint(' '.join(self.command_align ) + "\n" + ' '.join(self.command_fuse) + "\n")
         
     def run(self):
         if Gui.checkbutton_a5_align.get_active():       
@@ -1113,7 +1093,6 @@ class Apropos_Dialog:
         self.aboutdialog.set_position(Gtk.WindowPosition.CENTER)
         self.aboutdialog.set_version(__VERSION__)
         self.aboutdialog.set_comments('A GTK Gui for the excellent Enfuse.\n\n2014 (c) Dariusz Duma\n<dhor@toxic.net.pl>')
-        # self.aboutdialog.set_copyright(__COPYRIGHT__)
         self.aboutdialog.set_website(__WEBSITE__)
         self.pixbuf = GdkPixbuf.Pixbuf.new_from_file(IMG + "macrofusion.png")
         self.aboutdialog.set_logo(self.pixbuf)
@@ -1136,7 +1115,5 @@ if __name__ == "__main__":
     if (len(sys.argv)>1):     
         files = sys.argv[1:]
         Gui.put_files_to_the_list(files)
-#        if len(Gui.liststoreimport) == 0:
-#            Gui.messageinthebottle(_("\nCan work only with JPEG or TIFF files."))
 
     Gtk.main()

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -117,6 +117,8 @@ settings = {
         # Misc arguments
         "misc_args"             : ["-v",        True]
     },
+    # algin settings for thumbnails shouldn't include seetings which don't work well on tiny resolutions
+    "align_settings_thumbnail"  : ["-C", "-x", "-y", "-z", "-d", "-i", "-m", "--gpu"],
     "fuse_settings"             :
     {
         # default compression setting (for JPG/TIFF) 
@@ -203,9 +205,11 @@ class DataProvider:
                         options.append(value[0] + " " + str(value[1]))
         return options
     
-    @property
-    def get_align_options(self):
+    def get_align_options(self, low_resolution=False):
         options = []
+        if low_resolution:
+            return settings["align_settings_thumbnail"]
+    
         for key, value in settings["align_settings"].items():
             # special treatment for boolean values
             if (key == "auto_crop" or  key == "use_gpu" or key == "misc_args" or \
@@ -924,7 +928,7 @@ class Thread_Preview(threading.Thread):
         if not Gui.checkbutton_a5_align.get_active():
             images_a_fusionner = images_a_align
         if Gui.checkbutton_a5_align.get_active():
-            command = ["align_image_stack", "-a", os.path.join(settings["preview_folder"], "test")] + data.get_align_options + images_a_align
+            command = ["align_image_stack", "-a", os.path.join(settings["preview_folder"], "test")] + data.get_align_options(low_resolution=True) + images_a_align
             print(" ".join(command))
             Gui.statusbar.push(15, _(":: Align photos..."))
             preview_process = subprocess.Popen(command, stdout=subprocess.PIPE)
@@ -988,7 +992,7 @@ class Thread_Fusion(threading.Thread):
         self.img_list = img_list
         self.img_list_aligned = img_list_aligned
         self.command_fuse  = [data.get_all_settings["enfuser"], "-o", self.name] + data.get_enfuse_options + self.img_list_aligned
-        self.command_align = ["align_image_stack", '-a', os.path.join(settings["preview_folder"], settings["align_prefix"])] + data.get_align_options + self.img_list
+        self.command_align = ["align_image_stack", '-a', os.path.join(settings["preview_folder"], settings["align_prefix"])] + data.get_align_options() + self.img_list
 
         
     def run(self):

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -922,14 +922,14 @@ class Thread_Preview(threading.Thread):
             images_a_fusionner = images_a_align
         if Gui.checkbutton_a5_align.get_active():
             command = ["align_image_stack", "-a", os.path.join(settings["preview_folder"], "test")] + data.get_align_options() + images_a_align
-            print(command)
+            print(" ".join(command))
             Gui.statusbar.push(15, _(":: Align photos..."))
             preview_process = subprocess.Popen(command, stdout=subprocess.PIPE)
             preview_process.wait()
             Gui.statusbar.pop(15)
         Gui.statusbar.push(15, _(":: Fusing photos..."))
         command = [settings["enfuser"], "-o", os.path.join(settings["preview_folder"], "preview.tif")] + data.get_enfuse_options() + images_a_fusionner
-        print(command)
+        print(" ".join(command))
         preview_process = subprocess.Popen(command, stdout=subprocess.PIPE)
         preview_process.wait()
         Gui.statusbar.pop(15)
@@ -992,7 +992,7 @@ class Thread_Fusion(threading.Thread):
         
     def run(self):
         if Gui.checkbutton_a5_align.get_active():       
-            print(self.command_align)     
+            print(" ".join(self.command_align))
             align_process = subprocess.Popen(self.command_align, stdout=subprocess.PIPE)
             align_process.wait()
         
@@ -1019,7 +1019,7 @@ class Thread_Fusion(threading.Thread):
                     shutil.move(new_filename, new_filename_dst)
                     count += 1
 
-        print(self.command_fuse)
+        print(" ".join(self.command_fuse))
         fusion_process = subprocess.Popen(self.command_fuse, stdout=subprocess.PIPE)
         fusion_process.wait()
         

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -170,11 +170,6 @@ class DataProvider:
         self.settings = settings
         self.update_folders()
         settings["cpus"] = multiprocessing.cpu_count()
-        if settings["cpus"] > 1 and self.check_install("enfuse-mp"):
-            print("Will use all the powers of your CPU!")
-            settings["enfuser"] = "enfuse-mp"
-        else:  
-            settings["enfuser"] = "enfuse"
 
     def update_folders(self):        
         # save tmp files in current working folder
@@ -287,7 +282,6 @@ class Interface:
         self.buttonaddfile = self.gui.get_object("buttonaddfile")
         self.buttondelfile = self.gui.get_object("buttondelfile")
         self.statusbar = self.gui.get_object("status1")
-        self.statusbar.push(1,(_("CPU Cores: %s") % settings["cpus"]))
 
         self.hscaleexp = self.gui.get_object("hscaleexp")
         self.ajus_exp = Gtk.Adjustment(value=1, lower=0, upper=1, step_increment=0.1, page_increment=0.1, page_size=0)

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -706,7 +706,11 @@ class Interface:
                 settings["fuse_settings"]["contrast-edge-scale"][3] = str(self.spinbuttonLceF.get_value()) + '%'
             else:
                 settings["fuse_settings"]["contrast-edge-scale"][3] = str(self.spinbuttonLceF.get_value())
-        
+        else:
+            settings["fuse_settings"]["contrast-edge-scale"][1] = 0
+            settings["fuse_settings"]["contrast-edge-scale"][2] = 0
+            settings["fuse_settings"]["contrast-edge-scale"][3] = 0
+
         if self.check_ciecam.get_active():
             settings["fuse_settings"]["use_ciecam"][1] = True
 

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -73,7 +73,7 @@ locale.textdomain(APP)
 ####################################################
 ########Classe des données##########################
 ####################################################
-enfuse_gray_projector_options = ["anti-value", "average", "l-star", "lightness", "value", "luminance", "pl-star"]
+enfuse_gray_projector_options = ["average", "l-star", "lightness", "value", "luminance", "pl-star"]
 tiff_compression = {0:"NONE", 1:"PACKBITS", 2:"LZW", 3:"DEFLATE"}
 settings = {
     "install_folder"            : sys.path[0],
@@ -89,14 +89,14 @@ settings = {
     # Options overview: http://wiki.panotools.org/Align_image_stack
     {
         # Auto crop the image to the area covered by all images.
-        "auto_crop"             : ["-C",        True],
+        "auto_crop"             : ["-C",        False],
         # Optimize X coordinate of the camera position.
-        "opt_x_coord"           : ["-x",        True],
+        "opt_x_coord"           : ["-x",        False],
         # Optimize Y coordinate of the camera position.
-        "opt_y_coord"           : ["-y",        True],
+        "opt_y_coord"           : ["-y",        False],
         # Optimize Z coordinate of the camera position.
         # Useful for aligning more distorted images.
-        "opt_z_coord"           : ["-z",        True],
+        "opt_z_coord"           : ["-z",        False],
         # Optimize radial distortion for all images, except for first.
         "opt_radial_dist"       : ["-d",        True],
         # Optimize image center shift for all images, except for first.
@@ -107,11 +107,11 @@ settings = {
         # Use GPU for remapping.
         "use_gpu"               : ["--gpu",     True],
         # Correlation threshold for identifying control points (default: 0.9).
-        "corr_thres"            : ["--corr",    0.1],
+        #"corr_thres"            : ["--corr",    0.1],
         # Remove all control points with an error higher than num pixels (default: 3).
-        "ctrl_pnt_thr"          : ["-t",        1],
+        #"ctrl_pnt_thr"          : ["-t",        1],
         # Number of control points (per grid, see option -g) to create between adjacent images (default: 8).  
-        "num_ctrl_pnt"          : ["-c",        20],
+        #"num_ctrl_pnt"          : ["-c",        20],
         # Scale down image by 2^scale (default: 1). Scaling down images will improve speed at the cost of accuracy.
         "scale_down"            : ["-s",        0],
         # Misc arguments
@@ -621,7 +621,10 @@ class Interface:
         settings["fuse_settings"]["exposure-sigma"][1]      = self.spinbuttonsigma.get_value()
         settings["fuse_settings"]["contrast-weight"][1]     = self.spinbuttoncont.get_value()
         settings["fuse_settings"]["saturation-weight"][1]   = self.spinbuttonsat.get_value()
-        settings["fuse_settings"]["levels"][1]              = self.spinbuttonlevel.get_value_as_int()
+        if self.check_pyramidelevel.get_active():
+            settings["fuse_settings"]["levels"][1]          = self.spinbuttonlevel.get_value_as_int()
+        else:
+            settings["fuse_settings"]["levels"][1]          = 0
         if self.check_hardmask.get_active():
             settings["fuse_settings"]["hard-mask"][1] = True
             settings["fuse_settings"]["soft-mask"][1] = False

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -73,7 +73,7 @@ locale.textdomain(APP)
 ####################################################
 ########Classe des données##########################
 ####################################################
-enfuse_gray_projector_options = ["average", "l-star", "lightness", "value", "luminance", "pl-star"]
+enfuse_gray_projector_options = ["anti-value", "average", "l-star", "lightness", "value", "luminance", "pl-star"]
 tiff_compression = {0:"NONE", 1:"PACKBITS", 2:"LZW", 3:"DEFLATE"}
 settings = {
     "install_folder"            : sys.path[0],
@@ -107,11 +107,11 @@ settings = {
         # Use GPU for remapping.
         "use_gpu"               : ["--gpu",     True],
         # Correlation threshold for identifying control points (default: 0.9).
-        #"corr_thres"            : ["--corr",    0.1],
+        "corr_thres"            : ["--corr",    0.9],
         # Remove all control points with an error higher than num pixels (default: 3).
-        #"ctrl_pnt_thr"          : ["-t",        1],
+        "ctrl_pnt_thr"          : ["-t",        3],
         # Number of control points (per grid, see option -g) to create between adjacent images (default: 8).  
-        #"num_ctrl_pnt"          : ["-c",        20],
+        "num_ctrl_pnt"          : ["-c",        8],
         # Scale down image by 2^scale (default: 1). Scaling down images will improve speed at the cost of accuracy.
         "scale_down"            : ["-s",        0],
         # Misc arguments
@@ -140,10 +140,10 @@ settings = {
         # force hard blend masks and no averaging on finest scale
         "hard-mask"             : ["--hard-mask",               False],
         # apply gray-scale PROJECTOR in exposure or contrast weighing, where PROJECTOR is one of
-        # 0: "average", 1: "l-star", 2: "lightness", 3: "value", 4: "luminance", 5: "pl-star"
+        # 0: "anti-value", 1: "average", 2: "l-star", 3: "lightness", 4: "value", 5: "luminance", 6: "pl-star"
         "gray-projector"        : ["--gray-projector",          1],
         # set window SIZE for local-contrast analysis     
-        "contrast-window-size"  : ["--contrast-window-size",    3],
+        "contrast-window-size"  : ["--contrast-window-size",    5],
         # minimum CURVATURE for an edge to qualify; append "%" for relative values
         "contrast-min-curvature": ["--contrast-min-curvature",  0],
         # set scale on which to look for edges; positive LCESCALE switches on.
@@ -354,7 +354,7 @@ class Interface:
 
         #valeurs des options et configurations :
         self.check_pyramidelevel = self.gui.get_object("check_pyramidelevel")
-        self.check_pyramidelevel.set_active(1)
+        self.check_pyramidelevel.set_active(0)
 
         self.spinbuttonlevel = self.gui.get_object("spinbuttonlevel")
         self.spinbuttonlevel.set_value(settings["fuse_settings"]["levels"][1])
@@ -365,6 +365,13 @@ class Interface:
         self.check_contwin = self.gui.get_object("check_contwin")
         self.spinbuttoncontwin = self.gui.get_object("spinbuttoncontwin")
         self.spinbuttoncontwin.set_value(settings["fuse_settings"]["contrast-window-size"][1])
+        
+        self.check_xcoord = self.gui.get_object("check_x_coord")
+        self.check_xcoord.set_active(settings["align_settings"]["opt_x_coord"][1])
+        self.check_ycoord = self.gui.get_object("check_y_coord")
+        self.check_ycoord.set_active(settings["align_settings"]["opt_y_coord"][1])
+        self.check_zcoord = self.gui.get_object("check_z_coord")
+        self.check_zcoord.set_active(settings["align_settings"]["opt_z_coord"][1])
 
         self.check_courb = self.gui.get_object("check_courb")
         self.check_prctcourb = self.gui.get_object("check_prctcourb")
@@ -390,7 +397,28 @@ class Interface:
         self.check_desatmeth = self.gui.get_object("check_desatmeth")
         self.combobox_desatmet = self.gui.get_object("combobox_desatmet")
         self.combobox_desatmet.set_active(settings["fuse_settings"]["gray-projector"][1])
- 
+        
+        self.check_corrthres = self.gui.get_object("check_corrthres")
+        self.spinbuttoncorrthres = self.gui.get_object("spinbuttoncorrthres")
+        self.ajus_corrthres = Gtk.Adjustment(value=0.9, lower=0, upper=1, step_increment=0.1, page_increment=0.1, page_size=0)
+        self.spinbuttoncorrthres.set_adjustment(self.ajus_corrthres)
+        self.spinbuttoncorrthres.set_digits(2)
+        self.spinbuttoncorrthres.set_value(settings["align_settings"]["corr_thres"][1])
+
+        self.check_pnt = self.gui.get_object("check_pnt")
+        self.spinbuttonpnt = self.gui.get_object("spinbuttonpnt")
+        #self.ajus_corrthres = Gtk.Adjustment(value=0, lower=0, upper=1, step_increment=0.1, page_increment=0.1, page_size=0)
+        #self.spinbuttoncorrthres.set_adjustment(self.ajus_corrthres)
+        #self.spinbuttoncorrthres.set_digits(1)
+        self.spinbuttonpnt.set_value(int(settings["align_settings"]["num_ctrl_pnt"][1]))
+
+        self.check_pntthr = self.gui.get_object("check_pntthr")
+        self.spinbuttonpntthr = self.gui.get_object("spinbuttonpntthr")
+        #self.ajus_corrthres = Gtk.Adjustment(value=0, lower=0, upper=1, step_increment=0.1, page_increment=0.1, page_size=0)
+        #self.spinbuttoncorrthres.set_adjustment(self.ajus_corrthres)
+        #self.spinbuttoncorrthres.set_digits(1)
+        self.spinbuttonpntthr.set_value(int(settings["align_settings"]["ctrl_pnt_thr"][1]))
+
         self.spinbuttonlargeurprev = self.gui.get_object("spinbuttonlargeurprev")
         self.spinbuttonhauteurprev = self.gui.get_object("spinbuttonhauteurprev")
         self.checkbuttonbloc = self.gui.get_object("checkbuttonbloc")
@@ -407,7 +435,8 @@ class Interface:
         self.checkbutton_a5_align = self.gui.get_object("checkbutton_a5_align")
         self.checkbutton_a5_crop = self.gui.get_object("checkbutton_a5_crop")
         self.checkbutton_a5_shift = self.gui.get_object("checkbutton_a5_shift")
-        self.checkbutton_a5_field = self.gui.get_object("checkbutton_a5_field")                
+        self.checkbutton_a5_field = self.gui.get_object("checkbutton_a5_field")
+        self.checkbutton_a5_radial = self.gui.get_object("checkbutton_a5_radial")
         self.buttonabout = self.gui.get_object("buttonabout")
         
         self.entryedit_field = self.gui.get_object("entry_editor")                
@@ -425,12 +454,14 @@ class Interface:
         self.checkbutton_a5_crop.set_sensitive(False)
         self.checkbutton_a5_field.set_sensitive(False)
         self.checkbutton_a5_shift.set_sensitive(False)
+        self.checkbutton_a5_radial.set_sensitive(False)
         self.checkbuttonalignfiles.set_sensitive(False)
 
         # update gui according to settings
         self.checkbutton_a5_crop.set_active(settings["align_settings"]["auto_crop"][1])
         self.checkbutton_a5_field.set_active(settings["align_settings"]["opt_fov"][1])
         self.checkbutton_a5_shift.set_active(settings["align_settings"]["opt_img_shift"][1])
+        self.checkbutton_a5_radial.set_active(settings["align_settings"]["opt_radial_dist"][1])
 
         # Read values from config
         self.conf = configparser.ConfigParser()
@@ -505,11 +536,13 @@ class Interface:
             self.checkbutton_a5_crop.set_sensitive(True)
             self.checkbutton_a5_field.set_sensitive(True)
             self.checkbutton_a5_shift.set_sensitive(True)
+            self.checkbutton_a5_radial.set_sensitive(True)
             self.checkbuttonalignfiles.set_sensitive(True)
         else:
             self.checkbutton_a5_crop.set_sensitive(False)
             self.checkbutton_a5_field.set_sensitive(False)
             self.checkbutton_a5_shift.set_sensitive(False)
+            self.checkbutton_a5_radial.set_sensitive(False)
             self.checkbuttonalignfiles.set_sensitive(False)
 
     def exit_app(self, action):
@@ -611,9 +644,29 @@ class Interface:
 
     def update_align_options(self):
         if self.checkbutton_a5_align.get_active():
-            settings["align_settings"]["auto_crop"][1]     = self.checkbutton_a5_crop.get_active()
-            settings["align_settings"]["opt_img_shift"][1] = self.checkbutton_a5_shift.get_active()
-            settings["align_settings"]["opt_fov"][1]       = self.checkbutton_a5_field.get_active()
+            settings["align_settings"]["auto_crop"][1]          = self.checkbutton_a5_crop.get_active()
+            settings["align_settings"]["opt_img_shift"][1]      = self.checkbutton_a5_shift.get_active()
+            settings["align_settings"]["opt_fov"][1]            = self.checkbutton_a5_field.get_active()
+            settings["align_settings"]["opt_radial_dist"][1]    = self.checkbutton_a5_radial.get_active()
+        
+        if self.check_corrthres.get_active():
+            settings["align_settings"]["corr_thres"][1]       = self.spinbuttoncorrthres.get_value()
+        else:
+            settings["align_settings"]["corr_thres"][1]       = 0.0
+        
+        if self.check_pnt.get_active():
+            settings["align_settings"]["num_ctrl_pnt"][1]       = int(self.spinbuttonpnt.get_value())
+        else:
+            settings["align_settings"]["num_ctrl_pnt"][1]       = 0
+        
+        if self.check_pntthr.get_active():
+            settings["align_settings"]["ctrl_pnt_thr"][1]       = int(self.spinbuttonpntthr.get_value())
+        else:
+            settings["align_settings"]["ctrl_pnt_thr"][1]       = 0
+        
+        settings["align_settings"]["opt_x_coord"][1]       = self.check_xcoord.get_active()
+        settings["align_settings"]["opt_y_coord"][1]       = self.check_ycoord.get_active()
+        settings["align_settings"]["opt_z_coord"][1]       = self.check_zcoord.get_active()
 
     def update_enfuse_options(self):
         settings["fuse_settings"]["exposure-weight"][1]     = self.spinbuttonexp.get_value()
@@ -634,6 +687,8 @@ class Interface:
             
         if self.check_contwin.get_active():
             settings["fuse_settings"]["contrast-window-size"][1] = self.spinbuttoncontwin.get_value_as_int()
+        else:
+            settings["fuse_settings"]["contrast-window-size"][1] = 0
  
         if self.check_courb.get_active():
             if self.check_prctcourb.get_active():
@@ -1000,7 +1055,7 @@ class Thread_Fusion(threading.Thread):
         self.img_list_aligned = img_list_aligned
         self.command_fuse  = [data.get_all_settings["enfuser"], "-o", self.name] + data.get_enfuse_options + self.img_list_aligned
         self.command_align = ["align_image_stack", '-a', os.path.join(settings["preview_folder"], settings["align_prefix"])] + data.get_align_options() + self.img_list
-
+        #sprint(' '.join(self.command_align ) + "\n" + ' '.join(self.command_fuse) + "\n")
         
     def run(self):
         if Gui.checkbutton_a5_align.get_active():       

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -393,8 +393,6 @@ class Interface:
  
         self.spinbuttonlargeurprev = self.gui.get_object("spinbuttonlargeurprev")
         self.spinbuttonhauteurprev = self.gui.get_object("spinbuttonhauteurprev")
-        self.checkbuttoncache = self.gui.get_object("checkbuttoncache")
-        self.spinbuttoncache = self.gui.get_object("spinbuttoncache")
         self.checkbuttonbloc = self.gui.get_object("checkbuttonbloc")
         self.spinbuttonbloc = self.gui.get_object("spinbuttonbloc")
         self.checkbuttonfinalsize = self.gui.get_object("checkbuttonfinalsize")
@@ -442,14 +440,6 @@ class Interface:
             self.spinbuttonlargeurprev.set_value(self.conf.getint('prefs', 'pwidth'))
         if self.conf.has_option('prefs', 'pheight'):
             self.spinbuttonhauteurprev.set_value(self.conf.getint('prefs', 'pheight'))
-        if self.conf.has_option('prefs', 'cachebutton'):
-            self.checkbuttoncache.set_active(self.conf.getboolean('prefs', 'cachebutton'))
-        if self.conf.has_option('prefs', 'cachesize'):
-            self.spinbuttoncache.set_value(self.conf.getint('prefs', 'cachesize'))
-        if self.conf.has_option('prefs', 'blocbutton'):
-            self.checkbuttonbloc.set_active(self.conf.getboolean('prefs', 'blocbutton'))
-        if self.conf.has_option('prefs', 'blocsize'):
-            self.spinbuttonbloc.set_value(self.conf.getint('prefs', 'blocsize'))
         if self.conf.has_option('prefs', 'outsize'):
             self.checkbuttonfinalsize.set_active(self.conf.getboolean('prefs', 'outsize'))
         if self.conf.has_option('prefs', 'outwidth'):
@@ -775,10 +765,6 @@ class Interface:
         # conf.set('prefs', 'w', self.spinbuttonEdge.get_value_as_int())
         conf.set('prefs', 'pwidth', str(self.spinbuttonlargeurprev.get_value_as_int()))
         conf.set('prefs', 'pheight', str(self.spinbuttonhauteurprev.get_value_as_int()))
-        conf.set('prefs', 'cachebutton', str(self.checkbuttoncache.get_active()))
-        conf.set('prefs', 'cachesize', str(self.spinbuttoncache.get_value_as_int()))
-        conf.set('prefs', 'blocbutton', str(self.checkbuttonbloc.get_active()))
-        conf.set('prefs', 'blocsize', str(self.spinbuttonbloc.get_value_as_int()))
         conf.set('prefs', 'outsize', str(self.checkbuttonfinalsize.get_active()))
         conf.set('prefs', 'outwidth', str(self.spinbuttonfinalwidth.get_value_as_int()))
         conf.set('prefs', 'outheight', str(self.spinbuttonfinalheight.get_value_as_int()))

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -120,9 +120,9 @@ settings = {
         # weight given to pixels in high-contrast neighborhoods
         "contrast-weight"       : ["--contrast-weight",         0.0],
         # mean of Gaussian weighting function
-        "exposure-mu"           : ["--exposure-mu",             0.5],
+        "exposure-mu"           : ["--exposure-optimum",        0.5],
         # standard deviation of Gaussian weighting function 
-        "exposure-sigma"        : ["--exposure-sigma",          0.2],
+        "exposure-sigma"        : ["--exposure-width",          0.2],
         # limit number of blending LEVELS to use (1 to 29)
         "levels"                : ["--levels",                  29],
         # average over all masks; this is the default
@@ -146,10 +146,6 @@ settings = {
         #"save-masks"            : ["--save-masks", "%f-softmask-%n.png:%f-hardmask-%n.png"],
         # load masks from files
         #"load-masks"            : ["--load-masks", "%f-softmask-%n.png:%f-hardmask-%n.png"],
-        # image CACHESIZE in megabytes; default: 1024MB
-        "image_cachesize"       : ["-m",                        4096],
-        # image cache BLOCKSIZE in kilobytes; default: 2048KB
-        "image_cacheblocksize"  : ["-b",                        4096],
         # Misc arguments
         "misc_args"             : ["",                          False]
     }
@@ -656,12 +652,6 @@ class Interface:
 
         if self.check_desatmeth.get_active():
             settings["fuse_settings"]["gray-projector"][1] = self.combobox_desatmet.get_active()
-
-        if not self.checkbuttoncache.get_active():
-            settings["fuse_settings"]["image_cachesize"][1] = self.spinbuttoncache.get_value_as_int()
-
-        if not self.checkbuttonbloc.get_active():
-            settings["fuse_settings"]["image_cacheblocksize"][1] = self.spinbuttonbloc.get_value_as_int()
 
         if not self.checkbuttonfinalsize.get_active():
             settings["fuse_settings"]["output_dimensions"] = [ "-f",

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -152,6 +152,9 @@ settings = {
         "contrast-edge-scale"   : ["--contrast-edge-scale",     0, 0, 0],
         # use CIECAM02 to blend colors
         "use_ciecam"            : ["-c",                        False],
+        # use identified colorspace for blend operation to avoid colored pixel artifacts as mentioned here:
+        # https://discuss.pixls.us/t/enfuse-artifacts/4687
+        "identify_blend_colorspace": ["--blend-colorspace", "identity"],
         # save masks to files
         #"save-masks"            : ["--save-masks", "%f-softmask-%n.png:%f-hardmask-%n.png"],
         # load masks from files

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -103,8 +103,10 @@ settings = {
         "use_gpu"               : ["--gpu",     True],
         # Correlation threshold for identifying control points (default: 0.9).
         "corr_thres"            : ["--corr",    0.6],
+        # Optimize radial distortion for all images, except for first.
+        "opt_radial_dist"       : ["-d",        True],
         # Number of control points (per grid, see option -g) to create between adjacent images (default: 8).  
-        "num_ctrl_pnt"          : ["-c",        20],
+        "num_ctrl_pnt"          : ["-c",        40],
         # Scale down image by 2^scale (default: 1). Scaling down images will improve speed at the cost of accuracy.
         "scale_down"            : ["-s",        0],
         # Misc arguments
@@ -198,7 +200,8 @@ class data:
         options = []
         for key, value in settings["align_settings"].items():
             # special treatment for boolean values
-            if (key == "auto_crop" or key == "opt_img_shift" or key == "opt_fov" or key == "use_gpu" or key == "misc_args"):
+            if (key == "auto_crop" or key == "opt_img_shift" or key == "opt_fov" or key == "use_gpu" or \
+                key == "misc_args" or key == "opt_radial_dist"):
                 if value[1]:
                     options.append(value[0])
             else:

--- a/macrofusion.py
+++ b/macrofusion.py
@@ -70,8 +70,6 @@ locale.bindtextdomain(APP, DIR)
 locale.textdomain(APP)
 
 
-GObject.threads_init()
-
 
 
 ####################################################
@@ -277,7 +275,7 @@ class Interface:
         self.statusbar.push(1,(_("CPU Cores: %s") % settings["cpus"]))
 
         self.hscaleexp = self.gui.get_object("hscaleexp")
-        self.ajus_exp = Gtk.Adjustment(value=1, lower=0, upper=1, step_incr=0.1, page_incr=0.1, page_size=0)
+        self.ajus_exp = Gtk.Adjustment(value=1, lower=0, upper=1, step_increment=0.1, page_increment=0.1, page_size=0)
         self.hscaleexp.set_adjustment(self.ajus_exp)
         self.spinbuttonexp = self.gui.get_object("spinbuttonexp")
         self.spinbuttonexp.set_digits(1)
@@ -285,7 +283,7 @@ class Interface:
         self.spinbuttonexp.set_adjustment(self.ajus_exp)
         
         self.hscalecont = self.gui.get_object("hscalecont")
-        self.ajus_cont = Gtk.Adjustment(value=0, lower=0, upper=1, step_incr=0.1, page_incr=0.1, page_size=0)
+        self.ajus_cont = Gtk.Adjustment(value=0, lower=0, upper=1, step_increment=0.1, page_increment=0.1, page_size=0)
         self.hscalecont.set_adjustment(self.ajus_cont)
         self.spinbuttoncont = self.gui.get_object("spinbuttoncont")
         self.spinbuttoncont.set_digits(1)
@@ -293,7 +291,7 @@ class Interface:
         self.spinbuttoncont.set_adjustment(self.ajus_cont)
         
         self.hscalesat = self.gui.get_object("hscalesat")
-        self.ajus_sat = Gtk.Adjustment(value=0.2, lower=0, upper=1, step_incr=0.1, page_incr=0.1, page_size=0)
+        self.ajus_sat = Gtk.Adjustment(value=0.2, lower=0, upper=1, step_increment=0.1, page_increment=0.1, page_size=0)
         self.hscalesat.set_adjustment(self.ajus_sat)
         self.spinbuttonsat = self.gui.get_object("spinbuttonsat")
         self.spinbuttonsat.set_digits(1)
@@ -301,7 +299,7 @@ class Interface:
         self.spinbuttonsat.set_adjustment(self.ajus_sat)
         
         self.hscalemu = self.gui.get_object("hscalemu")
-        self.ajus_mu = Gtk.Adjustment(value=0.5, lower=0, upper=1, step_incr=0.01, page_incr=0.1, page_size=0)
+        self.ajus_mu = Gtk.Adjustment(value=0.5, lower=0, upper=1, step_increment=0.01, page_increment=0.1, page_size=0)
         self.hscalemu.set_adjustment(self.ajus_mu)
         self.spinbuttonmu = self.gui.get_object("spinbuttonmu")
         self.spinbuttonmu.set_digits(2)
@@ -309,7 +307,7 @@ class Interface:
         self.spinbuttonmu.set_adjustment(self.ajus_mu)
         
         self.hscalesigma = self.gui.get_object("hscalesigma")
-        self.ajus_sigma = Gtk.Adjustment(value=0.2, lower=0, upper=1, step_incr=0.01, page_incr=0.1, page_size=0)
+        self.ajus_sigma = Gtk.Adjustment(value=0.2, lower=0, upper=1, step_increment=0.01, page_increment=0.1, page_size=0)
         self.hscalesigma.set_adjustment(self.ajus_sigma)
         self.spinbuttonsigma = self.gui.get_object("spinbuttonsigma")
         self.spinbuttonsigma.set_digits(2)
@@ -317,11 +315,11 @@ class Interface:
         self.spinbuttonsigma.set_adjustment(self.ajus_sigma)
 
         self.spinbuttonlargeurprev = self.gui.get_object("spinbuttonlargeurprev")
-        self.ajus_largeup = Gtk.Adjustment(value=640, lower=128, upper=1280, step_incr=1, page_incr=1, page_size=0)
+        self.ajus_largeup = Gtk.Adjustment(value=640, lower=128, upper=1280, step_increment=1, page_increment=1, page_size=0)
         self.spinbuttonlargeurprev.set_adjustment(self.ajus_largeup)
 
         self.spinbuttonhauteurprev = self.gui.get_object("spinbuttonhauteurprev")
-        self.ajus_hauteup = Gtk.Adjustment(value=640, lower=128, upper=1280, step_incr=1, page_incr=1, page_size=0)
+        self.ajus_hauteup = Gtk.Adjustment(value=640, lower=128, upper=1280, step_increment=1, page_increment=1, page_size=0)
         self.spinbuttonhauteurprev.set_adjustment(self.ajus_hauteup)
         
         self.buttonpreview = self.gui.get_object("buttonpreview")
@@ -557,7 +555,6 @@ class Interface:
         self.colonneimages2.add_attribute(self.cell2, 'pixbuf', 2)
         self.cell2.set_property('visible', 1)
         
-        self.listimages.set_rules_hint(True)
         self.select.connect("toggled", toggled_cb, (self.liststoreimport, 0))   #Pour que les boutons de selection marchent
 
         # enable drag and drop destination for files
@@ -708,7 +705,8 @@ class Interface:
             return
         
     def messageinthebottle(self, message):
-        self.messaga = Gtk.MessageDialog(parent=self.win, flags=Gtk.DialogFlags.MODAL, type=Gtk.MessageType.INFO, buttons=Gtk.ButtonsType.OK, message_format=(message))
+        self.messaga = Gtk.MessageDialog(parent=self.win, modal=True,
+                                         message_type=Gtk.MessageType.INFO, buttons=Gtk.ButtonsType.OK, text=(message))
         if self.messaga.run() == Gtk.ResponseType.OK:
             self.messaga.destroy()
 
@@ -824,12 +822,10 @@ class OpenFiles_Dialog:
         self.filter = Gtk.FileFilter()
         self.filter.add_mime_type("image/jpeg")
         self.filter.add_mime_type("image/tiff")
-        self.liststoreimport = model #on repart de l'ancien modele
-
-        self.file_dialog = Gtk.FileChooserDialog(_("Add images..."), 
-                                                    parent, 
-                                                    Gtk.FileChooserAction.OPEN,
-                                                    (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,Gtk.STOCK_OK, Gtk.ResponseType.OK))
+        self.liststoreimport = model 
+        self.file_dialog = Gtk.FileChooserDialog(title=_("Add images..."),
+                                                parent=parent, action=Gtk.FileChooserAction.OPEN)
+        self.file_dialog.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OK, Gtk.ResponseType.OK)
         self.file_dialog.set_select_multiple(True)
         self.file_dialog.set_current_folder(settings["default_folder"])
         self.file_dialog.set_filter(self.filter)
@@ -876,10 +872,9 @@ class SaveFiles_Dialog:
     """La classe qui ouvre la fenetre de choix pour enregistrer le fichier"""          
     def __init__(self, parent):
         
-        self.file_dialog = Gtk.FileChooserDialog(_("Save file..."), 
-                                                   parent, 
-                                                   Gtk.FileChooserAction.SAVE,
-                                                   (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
+        self.file_dialog = Gtk.FileChooserDialog(title=_("Save file..."), 
+                                                 parent=parent, action=Gtk.FileChooserAction.SAVE)
+        self.file_dialog.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
         self.file_dialog.set_current_folder(settings["default_folder"])
         self.file_dialog.set_current_name(settings["default_file"])
         self.file_dialog.set_do_overwrite_confirmation(True)
@@ -941,8 +936,6 @@ class Thread_Preview(threading.Thread):
         
 class Progress_Fusion:
     def __init__(self, name, list, list_aligned, issend):
-        
-        #self.progress = Gtk.glade.XML(fname=UI + "progress.xml", domain=APP)
         self.progress = Gtk.Builder()
         self.progress.add_from_file(UI + "progress.xml") 
         self.progress_win = self.progress.get_object("dialog1")
@@ -953,17 +946,17 @@ class Progress_Fusion:
         self.dic1 = { "on_stop_button_clicked"  : self.close_progress, 
                       "on_dialog1_destroy"      : self.close_progress }
         self.progress.connect_signals(self.dic1)        
-        self.info_label.set_text(_('Fusion images...'))
+        self.info_label.set_text(_('Fusing images...'))
        
-        self.thread_fusion = Thread_Fusion(name, list, list_aligned, issend)  #On prepare le thread qui va faire tout le boulot
-        self.thread_fusion.start()                                     #On le lance
+        self.thread_fusion = Thread_Fusion(name, list, list_aligned, issend)
+        self.thread_fusion.start()
         timer = GObject.timeout_add (100, self.pulsate)
         
     def pulsate(self):
-        if self.thread_fusion.isAlive():            #Tant que le thread est en cours, 
-            self.progress_bar.set_text(_("Fusion, please wait..."))
-            self.progress_bar.pulse()               #on fait pulser la barre
-            return True                             #et on renvoie True pour que gobject.timeout recommence
+        if self.thread_fusion.is_alive():
+            self.progress_bar.set_text(_("Fusing images, please wait..."))
+            self.progress_bar.pulse()
+            return True
         else:
             self.progress_bar.set_fraction(1)
             self.progress_bar.set_text(_("Fused !"))

--- a/ui/progress.xml
+++ b/ui/progress.xml
@@ -1,48 +1,27 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
 <interface>
-  <!-- interface-requires gtk+ 2.16 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="dialog1">
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
-    <property name="type_hint">normal</property>
     <property name="modal">True</property>
-    <signal handler="on_dialog1_destroy" name="destroy"/>
+    <property name="type_hint">normal</property>
+    <signal name="destroy" handler="on_dialog1_destroy" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox1">
+      <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
-        <child>
-          <object class="GtkLabel" id="info_label">
-            <property name="visible">True</property>
-            <property name="label" translatable="yes">label</property>
-          </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkProgressBar" id="progressbar1">
-            <property name="visible">True</property>
-          </object>
-          <packing>
-            <property name="fill">False</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="progress_label">
-            <property name="visible">True</property>
-            <property name="xalign">0</property>
-          </object>
-          <packing>
-            <property name="position">3</property>
-          </packing>
-        </child>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area1">
+          <object class="GtkButtonBox" id="dialog-action_area1">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="stop_button">
@@ -50,7 +29,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <signal handler="on_stop_button_clicked" name="clicked"/>
+                <signal name="clicked" handler="on_stop_button_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -61,8 +40,44 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="info_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">label</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkProgressBar" id="progressbar1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="progress_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="xalign">0</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/ui/ui.xml
+++ b/ui/ui.xml
@@ -903,219 +903,6 @@ Optimize radial distortion for all images, except for first.
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="border-width">4</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="check_corrthres">
-                                            <property name="label" translatable="yes">correlation threshold</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">--corr
-
-Correlation threshold for identifying control points (default: 0.9).</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spinbuttoncorrthres">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="invisible-char">.</property>
-                                            <property name="secondary-icon-activatable">False</property>
-                                            <property name="adjustment">adjustment27</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSeparator">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="border-width">4</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="check_pnt">
-                                            <property name="label" translatable="yes">control points</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">-c
-
-Number of control points to create between adjacent images (default: 8).</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spinbuttonpnt">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="adjustment">adjustment28</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSeparator">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">3</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSeparator">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">4</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="border-width">4</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="check_pntthr">
-                                            <property name="label" translatable="yes">control points threshold</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">-t
-
-Remove all control points with an error higher than num pixels (default: 3).</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spinbuttonpntthr">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="adjustment">adjustment29</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">5</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSeparator">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">6</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label">
-                              <object class="GtkLabel" id="label15">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">&lt;b&gt;Expert Align Options&lt;/b&gt;</property>
-                                <property name="use-markup">True</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child type="tab">
-                          <object class="GtkLabel" id="label3">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Expert Align</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                            <property name="tab-fill">False</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="border-width">4</property>
-                            <property name="label-xalign">1</property>
-                            <child>
-                              <object class="GtkAlignment">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="left-padding">12</property>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="orientation">vertical</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="border-width">4</property>
                                         <property name="homogeneous">True</property>
                                         <child>
                                           <object class="GtkCheckButton" id="check_x_coord">
@@ -1174,6 +961,222 @@ Optimize Z coordinate of the camera position.</property>
                                         <property name="fill">True</property>
                                         <property name="position">0</property>
                                       </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">4</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="check_corrthres">
+                                            <property name="label" translatable="yes">correlation threshold</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">--corr
+
+Correlation threshold for identifying control points (default: 0.9).</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spinbuttoncorrthres">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="invisible-char">.</property>
+                                            <property name="secondary-icon-activatable">False</property>
+                                            <property name="adjustment">adjustment27</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">4</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="check_pnt">
+                                            <property name="label" translatable="yes">control points</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">-c
+
+Number of control points to create between adjacent images (default: 8).</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spinbuttonpnt">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="adjustment">adjustment28</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">5</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">4</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="check_pntthr">
+                                            <property name="label" translatable="yes">control points threshold</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">-t
+
+Remove all control points with an error higher than num pixels (default: 3).</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spinbuttonpntthr">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="adjustment">adjustment29</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">6</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">7</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                            <child type="label">
+                              <object class="GtkLabel" id="label15">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">&lt;b&gt;Expert Align Options&lt;/b&gt;</property>
+                                <property name="use-markup">True</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child type="tab">
+                          <object class="GtkLabel" id="label3">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Expert Align</property>
+                          </object>
+                          <packing>
+                            <property name="position">1</property>
+                            <property name="tab-fill">False</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkFrame">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="border-width">4</property>
+                            <property name="label-xalign">1</property>
+                            <child>
+                              <object class="GtkAlignment">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="left-padding">12</property>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="orientation">vertical</property>
+                                    <child>
+                                      <placeholder/>
                                     </child>
                                     <child>
                                       <object class="GtkSeparator">

--- a/ui/ui.xml
+++ b/ui/ui.xml
@@ -896,23 +896,19 @@ Useful for aligning focus stacks with slightly different magnification.
                                     <property name="can-focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="hbox8">
+                                      <object class="GtkBox">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="border-width">4</property>
                                         <child>
-                                          <object class="GtkCheckButton" id="check_pyramidelevel">
-                                            <property name="label" translatable="yes">Pyramid levels: </property>
-                                            <property name="use-action-appearance">False</property>
+                                          <object class="GtkCheckButton" id="check_corrthres">
+                                            <property name="label" translatable="yes">correlation threshold</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
-                                            <property name="tooltip-text">
---levels=LEVELS
+                                            <property name="tooltip-text" translatable="yes">--corr
 
-number of blending LEVELS to use
-					    </property>
-                                            <property name="xalign">0.5</property>
+Correlation threshold for identifying control points (default: 0.9).</property>
                                             <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
@@ -922,35 +918,28 @@ number of blending LEVELS to use
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkSpinButton" id="spinbuttonlevel">
+                                          <object class="GtkSpinButton" id="spinbuttoncorrthres">
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
-                                            <property name="tooltip-text">
---levels=LEVELS
-
-number of blending LEVELS to use
-					    </property>
-                                            <property name="invisible-char">•</property>
-                                            <property name="primary-icon-activatable">False</property>
+                                            <property name="invisible-char">.</property>
                                             <property name="secondary-icon-activatable">False</property>
-                                            <property name="adjustment">adjustment11</property>
+                                            <property name="adjustment">adjustment27</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack-type">end</property>
+                                            <property name="fill">True</property>
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
-                                        <property name="fill">False</property>
+                                        <property name="fill">True</property>
                                         <property name="position">0</property>
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkHSeparator" id="hseparator5">
+                                      <object class="GtkSeparator">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                       </object>
@@ -961,35 +950,45 @@ number of blending LEVELS to use
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkCheckButton" id="check_hardmask">
-                                        <property name="label" translatable="yes">Force HardMask </property>
-                                        <property name="use-action-appearance">False</property>
+                                      <object class="GtkBox">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-text">
---hard-mask
-
-force hard blend masks and no averaging on finest
-scale; this is especially useful for focus
-stacks with thin and high contrast features,
-but leads to increased noise.
-                                    </property>
-                                        <property name="margin-left">4</property>
-                                        <property name="margin-right">4</property>
-                                        <property name="margin-top">4</property>
-                                        <property name="margin-bottom">4</property>
-                                        <property name="xalign">0.5</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="border-width">4</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="check_pnt">
+                                            <property name="label" translatable="yes">control points</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spinbuttonpnt">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="adjustment">adjustment28</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
-                                        <property name="fill">False</property>
+                                        <property name="fill">True</property>
                                         <property name="position">2</property>
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkHSeparator" id="hseparator2">
+                                      <object class="GtkSeparator">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                       </object>
@@ -1000,23 +999,27 @@ but leads to increased noise.
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkBox" id="hbox2">
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="border-width">4</property>
                                         <child>
-                                          <object class="GtkCheckButton" id="check_contwin">
-                                            <property name="label" translatable="yes">Contrast window:</property>
-                                            <property name="use-action-appearance">False</property>
+                                          <object class="GtkCheckButton" id="check_pntthr">
+                                            <property name="label" translatable="yes">control points threshold</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
-                                            <property name="tooltip-text">
---contrast-window-size=SIZE
-
-set window SIZE for local-contrast analysis
-					    </property>
-                                            <property name="xalign">0.5</property>
                                             <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
@@ -1026,37 +1029,17 @@ set window SIZE for local-contrast analysis
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkSpinButton" id="spinbuttoncontwin">
+                                          <object class="GtkSpinButton" id="spinbuttonpntthr">
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
-                                            <property name="tooltip-text">
---contrast-window-size=SIZE
-
-set window SIZE for local-contrast analysis.
-                                        </property>
-                                            <property name="invisible-char">•</property>
-                                            <property name="primary-icon-activatable">False</property>
-                                            <property name="secondary-icon-activatable">False</property>
-                                            <property name="adjustment">adjustment12</property>
+                                            <property name="adjustment">adjustment29</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack-type">end</property>
+                                            <property name="fill">True</property>
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">4</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkHSeparator" id="hseparator9">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1064,6 +1047,61 @@ set window SIZE for local-contrast analysis.
                                         <property name="position">5</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">6</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                            <child type="label">
+                              <object class="GtkLabel" id="label15">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">&lt;b&gt;Expert Align Options&lt;/b&gt;</property>
+                                <property name="use-markup">True</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child type="tab">
+                          <object class="GtkLabel" id="label3">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Expert Align</property>
+                          </object>
+                          <packing>
+                            <property name="position">1</property>
+                            <property name="tab-fill">False</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkFrame">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="border-width">4</property>
+                            <property name="label-xalign">1</property>
+                            <child>
+                              <object class="GtkAlignment">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="left-padding">12</property>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="visible">True</property>
@@ -1125,7 +1163,7 @@ Optimize Z coordinate of the camera position.</property>
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">6</property>
+                                        <property name="position">0</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1136,308 +1174,7 @@ Optimize Z coordinate of the camera position.</property>
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">7</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkHSeparator" id="hseparator4">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">8</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkCheckButton" id="check_detecbord">
-                                        <property name="label" translatable="yes">EdgeScale:</property>
-                                        <property name="use-action-appearance">False</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-text">
---contrast-edge-scale=EDGESCALE[:LCESCALE[:LCEFACTOR]]
-
-set scale on which to look for edges; positive
-LCESCALE switches on local contrast enhancement
-by LCEFACTOR (EDGESCALE, LCESCALE, LCEFACTOR &gt;= 0);
-append "%" to LCESCALE for values relative to
-EDGESCALE; append "%" to LCEFACTOR for relative
-value.
-                                    </property>
-                                        <property name="margin-left">4</property>
-                                        <property name="margin-right">4</property>
-                                        <property name="margin-top">4</property>
-                                        <property name="border-width">0</property>
-                                        <property name="xalign">0.5</property>
-                                        <property name="draw-indicator">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">9</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox15">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="border-width">4</property>
-                                        <child>
-                                          <object class="GtkBox" id="vbox4">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="orientation">vertical</property>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spinbuttonEdge">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="tooltip-text">
-A non-zero value for EDGE-SCALE switches on the Laplacian-of-
-Gaussian (LoG) edge detection algorithm. EDGE-SCALE is the
-radius of the Gaussian used in the search for edges.
-                                            </property>
-                                                <property name="invisible-char">•</property>
-                                                <property name="primary-icon-activatable">False</property>
-                                                <property name="secondary-icon-activatable">False</property>
-                                                <property name="adjustment">adjustment14</property>
-                                                <property name="digits">1</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="label24">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="halign">start</property>
-                                                <property name="margin-left">5</property>
-                                                <property name="margin-top">4</property>
-                                                <property name="label" translatable="yes">EdgeScale</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="position">2</property>
-                                              </packing>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkBox" id="vbox14">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="orientation">vertical</property>
-                                            <child>
-                                              <object class="GtkBox" id="vbox14_">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <child>
-                                                  <object class="GtkSpinButton" id="spinbuttonLceF">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="tooltip-text">
-LCE-FACTOR is the weight factor (“strength”)
-                                            </property>
-                                                    <property name="invisible-char">•</property>
-                                                    <property name="primary-icon-activatable">False</property>
-                                                    <property name="secondary-icon-activatable">False</property>
-                                                    <property name="adjustment">adjustment16</property>
-                                                    <property name="digits">1</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">False</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="check_lcef">
-                                                    <property name="label">%</property>
-                                                    <property name="use-action-appearance">False</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="receives-default">False</property>
-                                                    <property name="tooltip-text">value as %</property>
-                                                    <property name="xalign">0.5</property>
-                                                    <property name="draw-indicator">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">True</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">1</property>
-                                                  </packing>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">True</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="label26">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="halign">start</property>
-                                                <property name="margin-left">5</property>
-                                                <property name="margin-top">4</property>
-                                                <property name="label" translatable="yes">LceFactor</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">False</property>
-                                            <property name="padding">6</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkBox" id="vbox5">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="orientation">vertical</property>
-                                            <child>
-                                              <object class="GtkBox" id="vbox5_">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <child>
-                                                  <object class="GtkSpinButton" id="spinbuttonLceS">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="tooltip-text">
-A positive LCE-SCALE turns on local contrast
-enhancement (LCE) before the LoG edge detection.
-LCE-SCALE is the radius of the Gaussian used in 
-the enhancement step, LCE-FACTOR is the weight
-factor (“strength”).
-                                            </property>
-                                                    <property name="invisible-char">•</property>
-                                                    <property name="primary-icon-activatable">False</property>
-                                                    <property name="secondary-icon-activatable">False</property>
-                                                    <property name="adjustment">adjustment15</property>
-                                                    <property name="digits">1</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">False</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="check_lces">
-                                                    <property name="label">%</property>
-                                                    <property name="use-action-appearance">False</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="receives-default">False</property>
-                                                    <property name="tooltip-text">value as %</property>
-                                                    <property name="xalign">0.5</property>
-                                                    <property name="draw-indicator">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">True</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">1</property>
-                                                  </packing>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">True</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="label25">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="halign">start</property>
-                                                <property name="margin-left">5</property>
-                                                <property name="margin-top">4</property>
-                                                <property name="label" translatable="yes">LceScale</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">10</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkHSeparator" id="hseparator7">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">11</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkCheckButton" id="check_ciecam">
-                                        <property name="label" translatable="yes">Use CIECAM02 color profile</property>
-                                        <property name="use-action-appearance">False</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-text">
--c
-
-use CIECAM02 to blend colors.
-                                    </property>
-                                        <property name="margin-left">4</property>
-                                        <property name="margin-right">4</property>
-                                        <property name="margin-top">4</property>
-                                        <property name="margin-bottom">4</property>
-                                        <property name="xalign">0.43000000715255737</property>
-                                        <property name="draw-indicator">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">12</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkHSeparator" id="hseparator1">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">13</property>
+                                        <property name="position">1</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1480,7 +1217,7 @@ use CIECAM02 to blend colors.
                                             <property name="label" translatable="yes">Gray projector:</property>
                                             <property name="use-action-appearance">False</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
                                             <property name="tooltip-text">
 --gray-projector=OPERATOR
@@ -1491,7 +1228,7 @@ or contrast weighing, where OPERATOR is one of
 "luminance", or
 "channel-mixer:RED-WEIGHT:GREEN-WEIGHT:BLUE-WEIGHT".
                                         </property>
-                                            <property name="xalign">0.5</property>
+                                            <property name="xalign">0</property>
                                             <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
@@ -1504,7 +1241,7 @@ or contrast weighing, where OPERATOR is one of
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">False</property>
-                                        <property name="position">14</property>
+                                        <property name="position">2</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1515,23 +1252,27 @@ or contrast weighing, where OPERATOR is one of
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">15</property>
+                                        <property name="position">3</property>
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkBox">
+                                      <object class="GtkBox" id="hbox8">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="border-width">4</property>
                                         <child>
-                                          <object class="GtkCheckButton" id="check_corrthres">
-                                            <property name="label" translatable="yes">correlation threshold</property>
+                                          <object class="GtkCheckButton" id="check_pyramidelevel">
+                                            <property name="label" translatable="yes">Pyramid levels: </property>
+                                            <property name="use-action-appearance">False</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">--corr
+                                            <property name="tooltip-text">
+--levels=LEVELS
 
-Correlation threshold for identifying control points (default: 0.9).</property>
+number of blending LEVELS to use
+					    </property>
+                                            <property name="xalign">0</property>
                                             <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
@@ -1541,24 +1282,33 @@ Correlation threshold for identifying control points (default: 0.9).</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkSpinButton" id="spinbuttoncorrthres">
+                                          <object class="GtkSpinButton" id="spinbuttonlevel">
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
-                                            <property name="invisible-char">.</property>
+                                            <property name="tooltip-text">
+--levels=LEVELS
+
+number of blending LEVELS to use
+					    </property>
+                                            <property name="invisible-char">•</property>
+                                            <property name="text" translatable="yes">29</property>
+                                            <property name="primary-icon-activatable">False</property>
                                             <property name="secondary-icon-activatable">False</property>
-                                            <property name="adjustment">adjustment27</property>
+                                            <property name="adjustment">adjustment11</property>
+                                            <property name="value">29</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
-                                            <property name="fill">True</property>
+                                            <property name="fill">False</property>
+                                            <property name="pack-type">end</property>
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">16</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">4</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1569,20 +1319,64 @@ Correlation threshold for identifying control points (default: 0.9).</property>
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">17</property>
+                                        <property name="position">5</property>
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkBox">
+                                      <object class="GtkCheckButton" id="check_hardmask">
+                                        <property name="label" translatable="yes">Force HardMask </property>
+                                        <property name="use-action-appearance">False</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text">
+--hard-mask
+
+force hard blend masks and no averaging on finest
+scale; this is especially useful for focus
+stacks with thin and high contrast features,
+but leads to increased noise.
+                                    </property>
+                                        <property name="margin-top">4</property>
+                                        <property name="margin-bottom">4</property>
+                                        <property name="xalign">0</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">6</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">7</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="hbox2">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="border-width">4</property>
                                         <child>
-                                          <object class="GtkCheckButton" id="check_pnt">
-                                            <property name="label" translatable="yes">control points</property>
+                                          <object class="GtkCheckButton" id="check_contwin">
+                                            <property name="label" translatable="yes">Contrast window:</property>
+                                            <property name="use-action-appearance">False</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
+                                            <property name="tooltip-text">
+--contrast-window-size=SIZE
+
+set window SIZE for local-contrast analysis
+					    </property>
+                                            <property name="xalign">0</property>
                                             <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
@@ -1592,22 +1386,33 @@ Correlation threshold for identifying control points (default: 0.9).</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkSpinButton" id="spinbuttonpnt">
+                                          <object class="GtkSpinButton" id="spinbuttoncontwin">
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
-                                            <property name="adjustment">adjustment28</property>
+                                            <property name="tooltip-text">
+--contrast-window-size=SIZE
+
+set window SIZE for local-contrast analysis.
+                                        </property>
+                                            <property name="invisible-char">•</property>
+                                            <property name="text" translatable="yes">3</property>
+                                            <property name="primary-icon-activatable">False</property>
+                                            <property name="secondary-icon-activatable">False</property>
+                                            <property name="adjustment">adjustment12</property>
+                                            <property name="value">3</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
-                                            <property name="fill">True</property>
+                                            <property name="fill">False</property>
+                                            <property name="pack-type">end</property>
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">18</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">8</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1618,7 +1423,7 @@ Correlation threshold for identifying control points (default: 0.9).</property>
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">19</property>
+                                        <property name="position">9</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1629,67 +1434,7 @@ Correlation threshold for identifying control points (default: 0.9).</property>
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">20</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSeparator">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">21</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="border-width">4</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="check_pntthr">
-                                            <property name="label" translatable="yes">control points threshold</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spinbuttonpntthr">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="adjustment">adjustment29</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">22</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSeparator">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">23</property>
+                                        <property name="position">10</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1702,7 +1447,7 @@ Correlation threshold for identifying control points (default: 0.9).</property>
                                             <property name="label" translatable="yes">Min Curvature:</property>
                                             <property name="use-action-appearance">False</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
                                             <property name="tooltip-text">
 
@@ -1710,7 +1455,7 @@ Correlation threshold for identifying control points (default: 0.9).</property>
 
 minimum CURVATURE for an edge to qualify
 					    </property>
-                                            <property name="xalign">0.5</property>
+                                            <property name="xalign">0</property>
                                             <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
@@ -1724,9 +1469,9 @@ minimum CURVATURE for an edge to qualify
                                             <property name="label" translatable="yes">%</property>
                                             <property name="use-action-appearance">False</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
-                                            <property name="xalign">0.5</property>
+                                            <property name="xalign">0</property>
                                             <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
@@ -1746,6 +1491,7 @@ minimum CURVATURE for an edge to qualify
 minimum CURVATURE for an edge to qualify.
                                         </property>
                                             <property name="invisible-char">•</property>
+                                            <property name="text" translatable="yes">0</property>
                                             <property name="primary-icon-activatable">False</property>
                                             <property name="secondary-icon-activatable">False</property>
                                             <property name="adjustment">adjustment13</property>
@@ -1761,7 +1507,304 @@ minimum CURVATURE for an edge to qualify.
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">False</property>
-                                        <property name="position">24</property>
+                                        <property name="position">11</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">12</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="check_detecbord">
+                                        <property name="label" translatable="yes">EdgeScale:</property>
+                                        <property name="use-action-appearance">False</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text">
+--contrast-edge-scale=EDGESCALE[:LCESCALE[:LCEFACTOR]]
+
+set scale on which to look for edges; positive
+LCESCALE switches on local contrast enhancement
+by LCEFACTOR (EDGESCALE, LCESCALE, LCEFACTOR &gt;= 0);
+append "%" to LCESCALE for values relative to
+EDGESCALE; append "%" to LCEFACTOR for relative
+value.
+                                    </property>
+                                        <property name="margin-top">4</property>
+                                        <property name="border-width">0</property>
+                                        <property name="xalign">0</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">13</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="hbox15">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">4</property>
+                                        <child>
+                                          <object class="GtkBox" id="vbox4">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="orientation">vertical</property>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spinbuttonEdge">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="tooltip-text">
+A non-zero value for EDGE-SCALE switches on the Laplacian-of-
+Gaussian (LoG) edge detection algorithm. EDGE-SCALE is the
+radius of the Gaussian used in the search for edges.
+                                            </property>
+                                                <property name="invisible-char">•</property>
+                                                <property name="text" translatable="yes">0,0</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
+                                                <property name="adjustment">adjustment14</property>
+                                                <property name="digits">1</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label24">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="margin-top">4</property>
+                                                <property name="label" translatable="yes">EdgeScale</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox" id="vbox14">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="orientation">vertical</property>
+                                            <child>
+                                              <object class="GtkBox" id="vbox14_">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <child>
+                                                  <object class="GtkSpinButton" id="spinbuttonLceF">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="tooltip-text">
+LCE-FACTOR is the weight factor (“strength”)
+                                            </property>
+                                                    <property name="invisible-char">•</property>
+                                                    <property name="text" translatable="yes">0,0</property>
+                                                    <property name="primary-icon-activatable">False</property>
+                                                    <property name="secondary-icon-activatable">False</property>
+                                                    <property name="adjustment">adjustment16</property>
+                                                    <property name="digits">1</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">False</property>
+                                                    <property name="position">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkCheckButton" id="check_lcef">
+                                                    <property name="label">%</property>
+                                                    <property name="use-action-appearance">False</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="tooltip-text">value as %</property>
+                                                    <property name="xalign">0</property>
+                                                    <property name="draw-indicator">True</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">True</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">1</property>
+                                                  </packing>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label26">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="margin-top">4</property>
+                                                <property name="label" translatable="yes">LceFactor</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">False</property>
+                                            <property name="padding">6</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox" id="vbox5">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="orientation">vertical</property>
+                                            <child>
+                                              <object class="GtkBox" id="vbox5_">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <child>
+                                                  <object class="GtkSpinButton" id="spinbuttonLceS">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="tooltip-text">
+A positive LCE-SCALE turns on local contrast
+enhancement (LCE) before the LoG edge detection.
+LCE-SCALE is the radius of the Gaussian used in 
+the enhancement step, LCE-FACTOR is the weight
+factor (“strength”).
+                                            </property>
+                                                    <property name="invisible-char">•</property>
+                                                    <property name="text" translatable="yes">0,0</property>
+                                                    <property name="primary-icon-activatable">False</property>
+                                                    <property name="secondary-icon-activatable">False</property>
+                                                    <property name="adjustment">adjustment15</property>
+                                                    <property name="digits">1</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">False</property>
+                                                    <property name="position">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkCheckButton" id="check_lces">
+                                                    <property name="label">%</property>
+                                                    <property name="use-action-appearance">False</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="tooltip-text">value as %</property>
+                                                    <property name="xalign">0</property>
+                                                    <property name="draw-indicator">True</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">True</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">1</property>
+                                                  </packing>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label25">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="margin-top">4</property>
+                                                <property name="label" translatable="yes">LceScale</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">14</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">15</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="check_ciecam">
+                                        <property name="label" translatable="yes">Use CIECAM02 color profile</property>
+                                        <property name="use-action-appearance">False</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text">
+-c
+
+use CIECAM02 to blend colors.
+                                    </property>
+                                        <property name="margin-top">4</property>
+                                        <property name="margin-bottom">4</property>
+                                        <property name="xalign">0</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">16</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">17</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -1769,26 +1812,26 @@ minimum CURVATURE for an edge to qualify.
                               </object>
                             </child>
                             <child type="label">
-                              <object class="GtkLabel" id="label15">
+                              <object class="GtkLabel">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">&lt;b&gt;Expert Options&lt;/b&gt;</property>
+                                <property name="label" translatable="yes">&lt;b&gt;Expert Enfuse Options&lt;/b&gt;</property>
                                 <property name="use-markup">True</property>
                               </object>
                             </child>
                           </object>
                           <packing>
-                            <property name="position">1</property>
+                            <property name="position">2</property>
                           </packing>
                         </child>
                         <child type="tab">
-                          <object class="GtkLabel" id="label3">
+                          <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Expert</property>
+                            <property name="label" translatable="yes">Expert Enfuse</property>
                           </object>
                           <packing>
-                            <property name="position">1</property>
+                            <property name="position">2</property>
                             <property name="tab-fill">False</property>
                           </packing>
                         </child>
@@ -2468,7 +2511,7 @@ Enter name of graphics editor to edit images
                             </child>
                           </object>
                           <packing>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                         <child type="tab">
@@ -2478,7 +2521,7 @@ Enter name of graphics editor to edit images
                             <property name="label" translatable="yes">Save Options</property>
                           </object>
                           <packing>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
                             <property name="tab-fill">False</property>
                           </packing>
                         </child>

--- a/ui/ui.xml
+++ b/ui/ui.xml
@@ -840,6 +840,9 @@ Useful for aligning focus stacks with slightly different magnification.
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">
+Optimize radial distortion for all images, except for first.
+</property>
                                             <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
@@ -960,6 +963,9 @@ Correlation threshold for identifying control points (default: 0.9).</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">-c
+
+Number of control points to create between adjacent images (default: 8).</property>
                                             <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
@@ -1020,6 +1026,9 @@ Correlation threshold for identifying control points (default: 0.9).</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">-t
+
+Remove all control points with an error higher than num pixels (default: 3).</property>
                                             <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>

--- a/ui/ui.xml
+++ b/ui/ui.xml
@@ -1,151 +1,167 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="upper">1</property>
     <property name="value">1</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment10">
     <property name="upper">1</property>
-    <property name="value">0.20000000000000001</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="value">0.20</property>
+    <property name="step-increment">0.01</property>
+    <property name="page-increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment11">
     <property name="upper">29</property>
     <property name="value">29</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">29</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">29</property>
   </object>
   <object class="GtkAdjustment" id="adjustment12">
     <property name="lower">3</property>
     <property name="upper">7</property>
     <property name="value">3</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment13">
     <property name="lower">-10</property>
     <property name="upper">10</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment14">
     <property name="upper">100</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment15">
     <property name="upper">100</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment16">
     <property name="upper">100</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment17">
     <property name="lower">128</property>
     <property name="upper">1280</property>
     <property name="value">640</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment18">
     <property name="lower">128</property>
     <property name="upper">1280</property>
     <property name="value">640</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment19">
     <property name="upper">10000</property>
     <property name="value">1024</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment2">
     <property name="upper">1</property>
     <property name="value">1</property>
-    <property name="step_increment">0.10000000000000001</property>
+    <property name="step-increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment20">
     <property name="upper">10000</property>
     <property name="value">2048</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment21">
     <property name="upper">10000</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment22">
     <property name="upper">10000</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment23">
     <property name="upper">10000</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment24">
     <property name="upper">10000</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment25">
     <property name="upper">100</property>
     <property name="value">85</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment26">
     <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment27">
+    <property name="upper">1</property>
+    <property name="value">0.90</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">0.10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment28">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment29">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment3">
     <property name="upper">1</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment4">
     <property name="upper">1</property>
-    <property name="step_increment">0.10000000000000001</property>
+    <property name="step-increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment5">
     <property name="upper">1</property>
-    <property name="value">0.20000000000000001</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">10</property>
+    <property name="value">0.20</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment6">
     <property name="upper">1</property>
-    <property name="value">0.20000000000000001</property>
-    <property name="step_increment">0.10000000000000001</property>
+    <property name="value">0.20</property>
+    <property name="step-increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment7">
     <property name="upper">1</property>
     <property name="value">0.5</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="step-increment">0.01</property>
+    <property name="page-increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment8">
     <property name="upper">1</property>
     <property name="value">0.5</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="step-increment">0.01</property>
+    <property name="page-increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment9">
     <property name="upper">1</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="step-increment">0.01</property>
+    <property name="page-increment">0.10</property>
   </object>
   <object class="GtkListStore" id="model1">
     <columns>
@@ -154,10 +170,13 @@
     </columns>
     <data>
       <row>
-        <col id="0" translatable="yes">Mean</col>
+        <col id="0" translatable="yes">Anti-Value</col>
       </row>
       <row>
-        <col id="0" translatable="yes">L-star</col>
+        <col id="0" translatable="yes">Average</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">L-Star</col>
       </row>
       <row>
         <col id="0" translatable="yes">Lightness</col>
@@ -195,53 +214,50 @@
   </object>
   <object class="GtkWindow" id="mainwindow">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <signal name="destroy" handler="on_mainwindow_destroy" swapped="no"/>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox" id="hbox1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkBox" id="vbox12">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox" id="box2">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkFrame" id="frame8">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="valign">end</property>
-                        <property name="border_width">4</property>
-                        <property name="label_xalign">1</property>
+                        <property name="border-width">4</property>
+                        <property name="label-xalign">1</property>
                         <child>
                           <object class="GtkButtonBox" id="buttonbox1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="valign">end</property>
                             <property name="orientation">vertical</property>
-                            <property name="layout_style">start</property>
+                            <property name="layout-style">start</property>
                             <child>
                               <object class="GtkButton" id="buttonaddfile">
                                 <property name="label">gtk-add</property>
-                                <property name="use_action_appearance">False</property>
+                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="receives_default">True</property>
-                                <property name="border_width">4</property>
-                                <property name="use_stock">True</property>
-                                <property name="image_position">top</property>
+                                <property name="can-focus">False</property>
+                                <property name="receives-default">True</property>
+                                <property name="border-width">4</property>
+                                <property name="use-stock">True</property>
+                                <property name="image-position">top</property>
                                 <signal name="clicked" handler="on_buttonaddfile_clicked" swapped="no"/>
                                 <accelerator key="a" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
                               </object>
@@ -254,13 +270,13 @@
                             <child>
                               <object class="GtkButton" id="buttondelfile">
                                 <property name="label">gtk-remove</property>
-                                <property name="use_action_appearance">False</property>
+                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="receives_default">True</property>
-                                <property name="border_width">4</property>
-                                <property name="use_stock">True</property>
-                                <property name="image_position">top</property>
+                                <property name="can-focus">False</property>
+                                <property name="receives-default">True</property>
+                                <property name="border-width">4</property>
+                                <property name="use-stock">True</property>
+                                <property name="image-position">top</property>
                                 <signal name="clicked" handler="on_buttondelfile_clicked" swapped="no"/>
                                 <accelerator key="r" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
                               </object>
@@ -273,13 +289,13 @@
                             <child>
                               <object class="GtkButton" id="buttonclear">
                                 <property name="label">gtk-clear</property>
-                                <property name="use_action_appearance">False</property>
+                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="receives_default">True</property>
-                                <property name="border_width">4</property>
-                                <property name="use_stock">True</property>
-                                <property name="image_position">top</property>
+                                <property name="can-focus">False</property>
+                                <property name="receives-default">True</property>
+                                <property name="border-width">4</property>
+                                <property name="use-stock">True</property>
+                                <property name="image-position">top</property>
                                 <signal name="clicked" handler="on_buttonclear_clicked" swapped="no"/>
                                 <accelerator key="c" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
                               </object>
@@ -294,9 +310,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="Photos">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Photos&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                             <property name="ellipsize">end</property>
                           </object>
                         </child>
@@ -309,21 +325,21 @@
                     </child>
                     <child>
                       <object class="GtkScrolledWindow" id="scrolledwindow1">
-                        <property name="width_request">320</property>
-                        <property name="height_request">400</property>
+                        <property name="width-request">320</property>
+                        <property name="height-request">400</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="margin_right">4</property>
-                        <property name="margin_bottom">4</property>
-                        <property name="hscrollbar_policy">never</property>
-                        <property name="shadow_type">etched-in</property>
+                        <property name="can-focus">True</property>
+                        <property name="margin-right">4</property>
+                        <property name="margin-bottom">4</property>
+                        <property name="hscrollbar-policy">never</property>
+                        <property name="shadow-type">etched-in</property>
                         <child>
                           <object class="GtkTreeView" id="listimages">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="headers_clickable">False</property>
-                            <property name="enable_search">False</property>
-                            <property name="enable_grid_lines">horizontal</property>
+                            <property name="can-focus">False</property>
+                            <property name="headers-clickable">False</property>
+                            <property name="enable-search">False</property>
+                            <property name="enable-grid-lines">horizontal</property>
                             <child internal-child="selection">
                               <object class="GtkTreeSelection" id="treeview-selection1"/>
                             </child>
@@ -333,7 +349,7 @@
                       <packing>
                         <property name="expand">True</property>
                         <property name="fill">True</property>
-                        <property name="pack_type">end</property>
+                        <property name="pack-type">end</property>
                         <property name="position">2</property>
                       </packing>
                     </child>
@@ -348,38 +364,38 @@
                 <child>
                   <object class="GtkBox" id="vbox2">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkNotebook" id="notebook1">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="border_width">4</property>
+                        <property name="can-focus">True</property>
+                        <property name="border-width">4</property>
                         <child>
                           <object class="GtkBox" id="vbox3">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="frame3">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="border_width">4</property>
-                                <property name="label_xalign">1</property>
+                                <property name="can-focus">False</property>
+                                <property name="border-width">4</property>
+                                <property name="label-xalign">1</property>
                                 <child>
                                   <object class="GtkAlignment" id="alignment3">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="left_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vbox6">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label10">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Exposure (default: 1)</property>
                                             <property name="xalign">0</property>
                                           </object>
@@ -392,20 +408,20 @@
                                         <child>
                                           <object class="GtkBox" id="hbox3">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="border_width">4</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="border-width">4</property>
                                             <property name="spacing">8</property>
                                             <child>
                                               <object class="GtkHScale" id="hscaleexp">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="tooltip_text">
+                                                <property name="can-focus">False</property>
+                                                <property name="tooltip-text">
 --exposure-weight=WEIGHT
 
 weight given to well-exposed pixels
 						</property>
                                                 <property name="adjustment">adjustment1</property>
-                                                <property name="draw_value">False</property>
+                                                <property name="draw-value">False</property>
                                                 <signal name="format-value" handler="on_hscaleexp_format_value" swapped="no"/>
                                               </object>
                                               <packing>
@@ -417,15 +433,15 @@ weight given to well-exposed pixels
                                             <child>
                                               <object class="GtkSpinButton" id="spinbuttonexp">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="tooltip_text">
+                                                <property name="can-focus">True</property>
+                                                <property name="tooltip-text">
 --exposure-weight=WEIGHT
 
 weight given to well-exposed pixels
 						</property>
-                                                <property name="invisible_char">•</property>
-                                                <property name="primary_icon_activatable">False</property>
-                                                <property name="secondary_icon_activatable">False</property>
+                                                <property name="invisible-char">•</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
                                                 <property name="adjustment">adjustment2</property>
                                                 <property name="digits">1</property>
                                               </object>
@@ -445,7 +461,7 @@ weight given to well-exposed pixels
                                         <child>
                                           <object class="GtkLabel" id="label11">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Contrast (default: 0)</property>
                                             <property name="xalign">0</property>
                                           </object>
@@ -458,20 +474,20 @@ weight given to well-exposed pixels
                                         <child>
                                           <object class="GtkBox" id="hbox4">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="border_width">4</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="border-width">4</property>
                                             <property name="spacing">8</property>
                                             <child>
                                               <object class="GtkHScale" id="hscalecont">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="tooltip_text">
+                                                <property name="can-focus">False</property>
+                                                <property name="tooltip-text">
 --contrast-weight=WEIGHT
 
 weight given to pixels in high-contrast neighborhoods
 						</property>
                                                 <property name="adjustment">adjustment3</property>
-                                                <property name="draw_value">False</property>
+                                                <property name="draw-value">False</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">True</property>
@@ -482,15 +498,15 @@ weight given to pixels in high-contrast neighborhoods
                                             <child>
                                               <object class="GtkSpinButton" id="spinbuttoncont">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="tooltip_text">
+                                                <property name="can-focus">True</property>
+                                                <property name="tooltip-text">
 --contrast-weight=WEIGHT
 
 weight given to pixels in high-contrast neighborhoods
 						</property>
-                                                <property name="invisible_char">•</property>
-                                                <property name="primary_icon_activatable">False</property>
-                                                <property name="secondary_icon_activatable">False</property>
+                                                <property name="invisible-char">•</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
                                                 <property name="adjustment">adjustment4</property>
                                                 <property name="digits">1</property>
                                               </object>
@@ -510,7 +526,7 @@ weight given to pixels in high-contrast neighborhoods
                                         <child>
                                           <object class="GtkLabel" id="label12">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Saturation (default: 0.2)</property>
                                             <property name="xalign">0</property>
                                           </object>
@@ -523,20 +539,20 @@ weight given to pixels in high-contrast neighborhoods
                                         <child>
                                           <object class="GtkBox" id="hbox5">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="border_width">4</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="border-width">4</property>
                                             <property name="spacing">8</property>
                                             <child>
                                               <object class="GtkHScale" id="hscalesat">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="tooltip_text">
+                                                <property name="can-focus">False</property>
+                                                <property name="tooltip-text">
 --saturation-weight=WEIGHT
 
 weight given to highly-saturated pixels
 						</property>
                                                 <property name="adjustment">adjustment5</property>
-                                                <property name="draw_value">False</property>
+                                                <property name="draw-value">False</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">True</property>
@@ -547,15 +563,15 @@ weight given to highly-saturated pixels
                                             <child>
                                               <object class="GtkSpinButton" id="spinbuttonsat">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="tooltip_text">
+                                                <property name="can-focus">True</property>
+                                                <property name="tooltip-text">
 --saturation-weight=WEIGHT
 
 weight given to highly-saturated pixels
 						</property>
-                                                <property name="invisible_char">•</property>
-                                                <property name="primary_icon_activatable">False</property>
-                                                <property name="secondary_icon_activatable">False</property>
+                                                <property name="invisible-char">•</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
                                                 <property name="adjustment">adjustment6</property>
                                                 <property name="digits">1</property>
                                               </object>
@@ -575,7 +591,7 @@ weight given to highly-saturated pixels
                                         <child>
                                           <object class="GtkLabel" id="label13">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Mean exposure (default: 0.5)</property>
                                             <property name="xalign">0</property>
                                           </object>
@@ -588,20 +604,20 @@ weight given to highly-saturated pixels
                                         <child>
                                           <object class="GtkBox" id="hbox6">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="border_width">4</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="border-width">4</property>
                                             <property name="spacing">8</property>
                                             <child>
                                               <object class="GtkHScale" id="hscalemu">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="tooltip_text">
+                                                <property name="can-focus">False</property>
+                                                <property name="tooltip-text">
 --exposure-mu=MEAN
 
 center also known as MEAN of Gaussian weighting
 						</property>
                                                 <property name="adjustment">adjustment7</property>
-                                                <property name="draw_value">False</property>
+                                                <property name="draw-value">False</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">True</property>
@@ -612,15 +628,15 @@ center also known as MEAN of Gaussian weighting
                                             <child>
                                               <object class="GtkSpinButton" id="spinbuttonmu">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="tooltip_text">
+                                                <property name="can-focus">True</property>
+                                                <property name="tooltip-text">
 --exposure-mu=MEAN
 
 center also known as MEAN of Gaussian weighting
 						</property>
-                                                <property name="invisible_char">•</property>
-                                                <property name="primary_icon_activatable">False</property>
-                                                <property name="secondary_icon_activatable">False</property>
+                                                <property name="invisible-char">•</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
                                                 <property name="adjustment">adjustment8</property>
                                                 <property name="digits">1</property>
                                               </object>
@@ -640,7 +656,7 @@ center also known as MEAN of Gaussian weighting
                                         <child>
                                           <object class="GtkLabel" id="label14">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Deviation (default: 0.2)</property>
                                             <property name="xalign">0</property>
                                           </object>
@@ -653,21 +669,21 @@ center also known as MEAN of Gaussian weighting
                                         <child>
                                           <object class="GtkBox" id="hbox7">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="margin_bottom">4</property>
-                                            <property name="border_width">4</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="margin-bottom">4</property>
+                                            <property name="border-width">4</property>
                                             <property name="spacing">8</property>
                                             <child>
                                               <object class="GtkHScale" id="hscalesigma">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="tooltip_text">
+                                                <property name="can-focus">False</property>
+                                                <property name="tooltip-text">
 --exposure-sigma=SIGMA
 
 standard deviation of Gaussian weighting
 						</property>
                                                 <property name="adjustment">adjustment9</property>
-                                                <property name="draw_value">False</property>
+                                                <property name="draw-value">False</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">True</property>
@@ -678,15 +694,15 @@ standard deviation of Gaussian weighting
                                             <child>
                                               <object class="GtkSpinButton" id="spinbuttonsigma">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="tooltip_text">
+                                                <property name="can-focus">True</property>
+                                                <property name="tooltip-text">
 --exposure-sigma=SIGMA
 
 standard deviation of Gaussian weighting
 						</property>
-                                                <property name="invisible_char">•</property>
-                                                <property name="primary_icon_activatable">False</property>
-                                                <property name="secondary_icon_activatable">False</property>
+                                                <property name="invisible-char">•</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
                                                 <property name="adjustment">adjustment10</property>
                                                 <property name="digits">1</property>
                                               </object>
@@ -710,9 +726,9 @@ standard deviation of Gaussian weighting
                                 <child type="label">
                                   <object class="GtkLabel" id="label6">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">&lt;b&gt;Fusion parameters&lt;/b&gt;</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                   </object>
                                 </child>
                               </object>
@@ -725,31 +741,31 @@ standard deviation of Gaussian weighting
                             <child>
                               <object class="GtkFrame" id="frame_a5">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="border_width">4</property>
-                                <property name="label_xalign">1</property>
+                                <property name="can-focus">False</property>
+                                <property name="border-width">4</property>
+                                <property name="label-xalign">1</property>
                                 <child>
                                   <object class="GtkAlignment" id="alignment_a5">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="left_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vboxa_a5">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="checkbutton_a5_align">
                                             <property name="label" translatable="yes">Align</property>
-                                            <property name="use_action_appearance">False</property>
+                                            <property name="use-action-appearance">False</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text">
+                                            <property name="can-focus">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text">
 Auto align images.
 </property>
                                             <property name="xalign">0.5</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="on_checkbutton_a5_align_toggled" swapped="no"/>
                                           </object>
                                           <packing>
@@ -761,15 +777,15 @@ Auto align images.
                                         <child>
                                           <object class="GtkCheckButton" id="checkbutton_a5_crop">
                                             <property name="label" translatable="yes">Autocrop</property>
-                                            <property name="use_action_appearance">False</property>
+                                            <property name="use-action-appearance">False</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text">
+                                            <property name="can-focus">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text">
 Auto crop the image to the area covered by all images.
 </property>
                                             <property name="xalign">0.5</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -780,16 +796,16 @@ Auto crop the image to the area covered by all images.
                                         <child>
                                           <object class="GtkCheckButton" id="checkbutton_a5_shift">
                                             <property name="label" translatable="yes">Optimize image center shift</property>
-                                            <property name="use_action_appearance">False</property>
+                                            <property name="use-action-appearance">False</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text">
+                                            <property name="can-focus">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text">
 Optimize image center shift for all images, except for first.
 Useful for aligning more distorted images.
 </property>
                                             <property name="xalign">0.5</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -800,22 +816,36 @@ Useful for aligning more distorted images.
                                         <child>
                                           <object class="GtkCheckButton" id="checkbutton_a5_field">
                                             <property name="label" translatable="yes">Optimize field of view</property>
-                                            <property name="use_action_appearance">False</property>
+                                            <property name="use-action-appearance">False</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text">
+                                            <property name="can-focus">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text">
 Optimize field of view for all images, except for first.
 Useful for aligning focus stacks with slightly different magnification.
 </property>
-                                            <property name="margin_bottom">4</property>
+                                            <property name="margin-bottom">4</property>
                                             <property name="xalign">0.5</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
                                             <property name="fill">True</property>
                                             <property name="position">3</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="checkbutton_a5_radial">
+                                            <property name="label" translatable="yes">Optimize radial distortion</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">4</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -825,9 +855,9 @@ Useful for aligning focus stacks with slightly different magnification.
                                 <child type="label">
                                   <object class="GtkLabel" id="label_a5">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">&lt;b&gt;Align images&lt;/b&gt;</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                   </object>
                                 </child>
                               </object>
@@ -842,49 +872,48 @@ Useful for aligning focus stacks with slightly different magnification.
                         <child type="tab">
                           <object class="GtkLabel" id="label1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Fusion</property>
                           </object>
                           <packing>
-                            <property name="tab_fill">False</property>
+                            <property name="tab-fill">False</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkFrame" id="frame4">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="border_width">4</property>
-                            <property name="label_xalign">1</property>
+                            <property name="can-focus">False</property>
+                            <property name="border-width">4</property>
+                            <property name="label-xalign">1</property>
                             <child>
                               <object class="GtkAlignment" id="alignment4">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="left_padding">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="left-padding">12</property>
                                 <child>
                                   <object class="GtkBox" id="vbox8">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkBox" id="hbox8">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="border_width">4</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">4</property>
                                         <child>
                                           <object class="GtkCheckButton" id="check_pyramidelevel">
                                             <property name="label" translatable="yes">Pyramid levels: </property>
-                                            <property name="use_action_appearance">False</property>
+                                            <property name="use-action-appearance">False</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text">
+                                            <property name="can-focus">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text">
 --levels=LEVELS
 
 number of blending LEVELS to use
 					    </property>
                                             <property name="xalign">0.5</property>
-                                            <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -895,21 +924,21 @@ number of blending LEVELS to use
                                         <child>
                                           <object class="GtkSpinButton" id="spinbuttonlevel">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text">
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-text">
 --levels=LEVELS
 
 number of blending LEVELS to use
 					    </property>
-                                            <property name="invisible_char">•</property>
-                                            <property name="primary_icon_activatable">False</property>
-                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="invisible-char">•</property>
+                                            <property name="primary-icon-activatable">False</property>
+                                            <property name="secondary-icon-activatable">False</property>
                                             <property name="adjustment">adjustment11</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
+                                            <property name="pack-type">end</property>
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
@@ -923,7 +952,7 @@ number of blending LEVELS to use
                                     <child>
                                       <object class="GtkHSeparator" id="hseparator5">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -934,11 +963,11 @@ number of blending LEVELS to use
                                     <child>
                                       <object class="GtkCheckButton" id="check_hardmask">
                                         <property name="label" translatable="yes">Force HardMask </property>
-                                        <property name="use_action_appearance">False</property>
+                                        <property name="use-action-appearance">False</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip_text">
+                                        <property name="can-focus">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text">
 --hard-mask
 
 force hard blend masks and no averaging on finest
@@ -946,12 +975,12 @@ scale; this is especially useful for focus
 stacks with thin and high contrast features,
 but leads to increased noise.
                                     </property>
-                                        <property name="margin_left">4</property>
-                                        <property name="margin_right">4</property>
-                                        <property name="margin_top">4</property>
-                                        <property name="margin_bottom">4</property>
+                                        <property name="margin-left">4</property>
+                                        <property name="margin-right">4</property>
+                                        <property name="margin-top">4</property>
+                                        <property name="margin-bottom">4</property>
                                         <property name="xalign">0.5</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -962,7 +991,7 @@ but leads to increased noise.
                                     <child>
                                       <object class="GtkHSeparator" id="hseparator2">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -973,22 +1002,22 @@ but leads to increased noise.
                                     <child>
                                       <object class="GtkBox" id="hbox2">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="border_width">4</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">4</property>
                                         <child>
                                           <object class="GtkCheckButton" id="check_contwin">
                                             <property name="label" translatable="yes">Contrast window:</property>
-                                            <property name="use_action_appearance">False</property>
+                                            <property name="use-action-appearance">False</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text">
+                                            <property name="can-focus">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text">
 --contrast-window-size=SIZE
 
 set window SIZE for local-contrast analysis
 					    </property>
                                             <property name="xalign">0.5</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -999,21 +1028,21 @@ set window SIZE for local-contrast analysis
                                         <child>
                                           <object class="GtkSpinButton" id="spinbuttoncontwin">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text">
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-text">
 --contrast-window-size=SIZE
 
 set window SIZE for local-contrast analysis.
                                         </property>
-                                            <property name="invisible_char">•</property>
-                                            <property name="primary_icon_activatable">False</property>
-                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="invisible-char">•</property>
+                                            <property name="primary-icon-activatable">False</property>
+                                            <property name="secondary-icon-activatable">False</property>
                                             <property name="adjustment">adjustment12</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
+                                            <property name="pack-type">end</property>
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
@@ -1027,7 +1056,7 @@ set window SIZE for local-contrast analysis.
                                     <child>
                                       <object class="GtkHSeparator" id="hseparator9">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1036,81 +1065,84 @@ set window SIZE for local-contrast analysis.
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkBox" id="hbox16">
+                                      <object class="GtkBox">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="border_width">4</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">4</property>
+                                        <property name="homogeneous">True</property>
                                         <child>
-                                          <object class="GtkCheckButton" id="check_courb">
-                                            <property name="label" translatable="yes">Min Curvature:</property>
-                                            <property name="use_action_appearance">False</property>
+                                          <object class="GtkCheckButton" id="check_x_coord">
+                                            <property name="label" translatable="yes">Optimize X coordinate</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text">
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">-x
 
---contrast-min-curvature=CURVATURE
-
-minimum CURVATURE for an edge to qualify
-					    </property>
-                                            <property name="xalign">0.5</property>
-                                            <property name="draw_indicator">True</property>
+Optimize X coordinate of the camera position.</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="check_prctcourb">
-                                            <property name="label" translatable="yes">%</property>
-                                            <property name="use_action_appearance">False</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="xalign">0.5</property>
-                                            <property name="draw_indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="padding">5</property>
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkSpinButton" id="spinbuttoncourb">
+                                          <object class="GtkCheckButton" id="check_y_coord">
+                                            <property name="label" translatable="yes">Optimize Y coordinate</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text">
---contrast-min-curvature=CURVATURE
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">-y
 
-minimum CURVATURE for an edge to qualify.
-                                        </property>
-                                            <property name="invisible_char">•</property>
-                                            <property name="primary_icon_activatable">False</property>
-                                            <property name="secondary_icon_activatable">False</property>
-                                            <property name="adjustment">adjustment13</property>
+Optimize Y coordinate of the camera position.</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="check_z_coord">
+                                            <property name="label" translatable="yes">Optimize Z coordinate</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">-z
+
+Optimize Z coordinate of the camera position.</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
                                             <property name="position">3</property>
                                           </packing>
                                         </child>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
-                                        <property name="fill">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">6</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
                                         <property name="position">7</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkHSeparator" id="hseparator4">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1121,11 +1153,11 @@ minimum CURVATURE for an edge to qualify.
                                     <child>
                                       <object class="GtkCheckButton" id="check_detecbord">
                                         <property name="label" translatable="yes">EdgeScale:</property>
-                                        <property name="use_action_appearance">False</property>
+                                        <property name="use-action-appearance">False</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip_text">
+                                        <property name="can-focus">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text">
 --contrast-edge-scale=EDGESCALE[:LCESCALE[:LCEFACTOR]]
 
 set scale on which to look for edges; positive
@@ -1135,12 +1167,12 @@ append "%" to LCESCALE for values relative to
 EDGESCALE; append "%" to LCEFACTOR for relative
 value.
                                     </property>
-                                        <property name="margin_left">4</property>
-                                        <property name="margin_right">4</property>
-                                        <property name="margin_top">4</property>
-                                        <property name="border_width">0</property>
+                                        <property name="margin-left">4</property>
+                                        <property name="margin-right">4</property>
+                                        <property name="margin-top">4</property>
+                                        <property name="border-width">0</property>
                                         <property name="xalign">0.5</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1151,25 +1183,25 @@ value.
                                     <child>
                                       <object class="GtkBox" id="hbox15">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="border_width">4</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">4</property>
                                         <child>
                                           <object class="GtkBox" id="vbox4">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="orientation">vertical</property>
                                             <child>
                                               <object class="GtkSpinButton" id="spinbuttonEdge">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="tooltip_text">
+                                                <property name="can-focus">True</property>
+                                                <property name="tooltip-text">
 A non-zero value for EDGE-SCALE switches on the Laplacian-of-
 Gaussian (LoG) edge detection algorithm. EDGE-SCALE is the
 radius of the Gaussian used in the search for edges.
                                             </property>
-                                                <property name="invisible_char">•</property>
-                                                <property name="primary_icon_activatable">False</property>
-                                                <property name="secondary_icon_activatable">False</property>
+                                                <property name="invisible-char">•</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
                                                 <property name="adjustment">adjustment14</property>
                                                 <property name="digits">1</property>
                                               </object>
@@ -1182,10 +1214,10 @@ radius of the Gaussian used in the search for edges.
                                             <child>
                                               <object class="GtkLabel" id="label24">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="halign">start</property>
-                                                <property name="margin_left">5</property>
-                                                <property name="margin_top">4</property>
+                                                <property name="margin-left">5</property>
+                                                <property name="margin-top">4</property>
                                                 <property name="label" translatable="yes">EdgeScale</property>
                                               </object>
                                               <packing>
@@ -1202,102 +1234,24 @@ radius of the Gaussian used in the search for edges.
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkBox" id="vbox5">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="orientation">vertical</property>
-                                            <child>
-                                              <object class="GtkBox" id="vbox5_">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <child>
-                                                  <object class="GtkSpinButton" id="spinbuttonLceS">
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="tooltip_text">
-A positive LCE-SCALE turns on local contrast
-enhancement (LCE) before the LoG edge detection.
-LCE-SCALE is the radius of the Gaussian used in 
-the enhancement step, LCE-FACTOR is the weight
-factor (“strength”).
-                                            </property>
-                                                    <property name="invisible_char">•</property>
-                                                    <property name="primary_icon_activatable">False</property>
-                                                    <property name="secondary_icon_activatable">False</property>
-                                                    <property name="adjustment">adjustment15</property>
-                                                    <property name="digits">1</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">False</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="check_lces">
-                                                    <property name="label">%</property>
-                                                    <property name="use_action_appearance">False</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
-                                                    <property name="receives_default">False</property>
-                                                    <property name="tooltip_text">value as %</property>
-                                                    <property name="xalign">0.5</property>
-                                                    <property name="draw_indicator">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">True</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">1</property>
-                                                  </packing>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">True</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="label25">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="halign">start</property>
-                                                <property name="margin_left">5</property>
-                                                <property name="margin_top">4</property>
-                                                <property name="label" translatable="yes">LceScale</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
                                           <object class="GtkBox" id="vbox14">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="orientation">vertical</property>
                                             <child>
                                               <object class="GtkBox" id="vbox14_">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <child>
                                                   <object class="GtkSpinButton" id="spinbuttonLceF">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="tooltip_text">
+                                                    <property name="can-focus">True</property>
+                                                    <property name="tooltip-text">
 LCE-FACTOR is the weight factor (“strength”)
                                             </property>
-                                                    <property name="invisible_char">•</property>
-                                                    <property name="primary_icon_activatable">False</property>
-                                                    <property name="secondary_icon_activatable">False</property>
+                                                    <property name="invisible-char">•</property>
+                                                    <property name="primary-icon-activatable">False</property>
+                                                    <property name="secondary-icon-activatable">False</property>
                                                     <property name="adjustment">adjustment16</property>
                                                     <property name="digits">1</property>
                                                   </object>
@@ -1310,13 +1264,13 @@ LCE-FACTOR is the weight factor (“strength”)
                                                 <child>
                                                   <object class="GtkCheckButton" id="check_lcef">
                                                     <property name="label">%</property>
-                                                    <property name="use_action_appearance">False</property>
+                                                    <property name="use-action-appearance">False</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
-                                                    <property name="receives_default">False</property>
-                                                    <property name="tooltip_text">value as %</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="tooltip-text">value as %</property>
                                                     <property name="xalign">0.5</property>
-                                                    <property name="draw_indicator">True</property>
+                                                    <property name="draw-indicator">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">True</property>
@@ -1334,10 +1288,10 @@ LCE-FACTOR is the weight factor (“strength”)
                                             <child>
                                               <object class="GtkLabel" id="label26">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="halign">start</property>
-                                                <property name="margin_left">5</property>
-                                                <property name="margin_top">4</property>
+                                                <property name="margin-left">5</property>
+                                                <property name="margin-top">4</property>
                                                 <property name="label" translatable="yes">LceFactor</property>
                                               </object>
                                               <packing>
@@ -1354,6 +1308,84 @@ LCE-FACTOR is the weight factor (“strength”)
                                             <property name="position">2</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkBox" id="vbox5">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="orientation">vertical</property>
+                                            <child>
+                                              <object class="GtkBox" id="vbox5_">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <child>
+                                                  <object class="GtkSpinButton" id="spinbuttonLceS">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="tooltip-text">
+A positive LCE-SCALE turns on local contrast
+enhancement (LCE) before the LoG edge detection.
+LCE-SCALE is the radius of the Gaussian used in 
+the enhancement step, LCE-FACTOR is the weight
+factor (“strength”).
+                                            </property>
+                                                    <property name="invisible-char">•</property>
+                                                    <property name="primary-icon-activatable">False</property>
+                                                    <property name="secondary-icon-activatable">False</property>
+                                                    <property name="adjustment">adjustment15</property>
+                                                    <property name="digits">1</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">False</property>
+                                                    <property name="position">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkCheckButton" id="check_lces">
+                                                    <property name="label">%</property>
+                                                    <property name="use-action-appearance">False</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="tooltip-text">value as %</property>
+                                                    <property name="xalign">0.5</property>
+                                                    <property name="draw-indicator">True</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">True</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">1</property>
+                                                  </packing>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label25">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="margin-left">5</property>
+                                                <property name="margin-top">4</property>
+                                                <property name="label" translatable="yes">LceScale</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1364,7 +1396,7 @@ LCE-FACTOR is the weight factor (“strength”)
                                     <child>
                                       <object class="GtkHSeparator" id="hseparator7">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1375,21 +1407,21 @@ LCE-FACTOR is the weight factor (“strength”)
                                     <child>
                                       <object class="GtkCheckButton" id="check_ciecam">
                                         <property name="label" translatable="yes">Use CIECAM02 color profile</property>
-                                        <property name="use_action_appearance">False</property>
+                                        <property name="use-action-appearance">False</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip_text">
+                                        <property name="can-focus">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text">
 -c
 
 use CIECAM02 to blend colors.
                                     </property>
-                                        <property name="margin_left">4</property>
-                                        <property name="margin_right">4</property>
-                                        <property name="margin_top">4</property>
-                                        <property name="margin_bottom">4</property>
+                                        <property name="margin-left">4</property>
+                                        <property name="margin-right">4</property>
+                                        <property name="margin-top">4</property>
+                                        <property name="margin-bottom">4</property>
                                         <property name="xalign">0.43000000715255737</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1400,7 +1432,7 @@ use CIECAM02 to blend colors.
                                     <child>
                                       <object class="GtkHSeparator" id="hseparator1">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1411,12 +1443,12 @@ use CIECAM02 to blend colors.
                                     <child>
                                       <object class="GtkBox" id="hbox14">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="border_width">4</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">4</property>
                                         <child>
                                           <object class="GtkLabel" id="label8">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -1427,7 +1459,7 @@ use CIECAM02 to blend colors.
                                         <child>
                                           <object class="GtkComboBox" id="combobox_desatmet">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="model">model1</property>
                                             <child>
                                               <object class="GtkCellRendererText" id="renderer1"/>
@@ -1439,18 +1471,18 @@ use CIECAM02 to blend colors.
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
+                                            <property name="pack-type">end</property>
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="check_desatmeth">
                                             <property name="label" translatable="yes">Gray projector:</property>
-                                            <property name="use_action_appearance">False</property>
+                                            <property name="use-action-appearance">False</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text">
+                                            <property name="can-focus">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text">
 --gray-projector=OPERATOR
 
 apply gray-scale projection OPERATOR in exposure
@@ -1460,7 +1492,7 @@ or contrast weighing, where OPERATOR is one of
 "channel-mixer:RED-WEIGHT:GREEN-WEIGHT:BLUE-WEIGHT".
                                         </property>
                                             <property name="xalign">0.5</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -1475,6 +1507,263 @@ or contrast weighing, where OPERATOR is one of
                                         <property name="position">14</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">15</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">4</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="check_corrthres">
+                                            <property name="label" translatable="yes">correlation threshold</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">--corr
+
+Correlation threshold for identifying control points (default: 0.9).</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spinbuttoncorrthres">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="invisible-char">.</property>
+                                            <property name="secondary-icon-activatable">False</property>
+                                            <property name="adjustment">adjustment27</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">16</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">17</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">4</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="check_pnt">
+                                            <property name="label" translatable="yes">control points</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spinbuttonpnt">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="adjustment">adjustment28</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">18</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">19</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">20</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">21</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">4</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="check_pntthr">
+                                            <property name="label" translatable="yes">control points threshold</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spinbuttonpntthr">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="adjustment">adjustment29</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">22</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">23</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="hbox16">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">4</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="check_courb">
+                                            <property name="label" translatable="yes">Min Curvature:</property>
+                                            <property name="use-action-appearance">False</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text">
+
+--contrast-min-curvature=CURVATURE
+
+minimum CURVATURE for an edge to qualify
+					    </property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="check_prctcourb">
+                                            <property name="label" translatable="yes">%</property>
+                                            <property name="use-action-appearance">False</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="padding">5</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spinbuttoncourb">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-text">
+--contrast-min-curvature=CURVATURE
+
+minimum CURVATURE for an edge to qualify.
+                                        </property>
+                                            <property name="invisible-char">•</property>
+                                            <property name="primary-icon-activatable">False</property>
+                                            <property name="secondary-icon-activatable">False</property>
+                                            <property name="adjustment">adjustment13</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="pack-type">end</property>
+                                            <property name="position">3</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">24</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                               </object>
@@ -1482,9 +1771,9 @@ or contrast weighing, where OPERATOR is one of
                             <child type="label">
                               <object class="GtkLabel" id="label15">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">&lt;b&gt;Expert Options&lt;/b&gt;</property>
-                                <property name="use_markup">True</property>
+                                <property name="use-markup">True</property>
                               </object>
                             </child>
                           </object>
@@ -1495,45 +1784,45 @@ or contrast weighing, where OPERATOR is one of
                         <child type="tab">
                           <object class="GtkLabel" id="label3">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Expert</property>
                           </object>
                           <packing>
                             <property name="position">1</property>
-                            <property name="tab_fill">False</property>
+                            <property name="tab-fill">False</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkBox" id="label_c5">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="frame5">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="border_width">4</property>
-                                <property name="label_xalign">1</property>
+                                <property name="can-focus">False</property>
+                                <property name="border-width">4</property>
+                                <property name="label-xalign">1</property>
                                 <child>
                                   <object class="GtkAlignment" id="alignment5">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="left_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vbox15">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="valign">start</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkBox" id="hbox17">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="border_width">4</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="border-width">4</property>
                                             <child>
                                               <object class="GtkLabel" id="label">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Preview size:</property>
                                                 <property name="ellipsize">middle</property>
                                               </object>
@@ -1546,26 +1835,26 @@ or contrast weighing, where OPERATOR is one of
                                             <child>
                                               <object class="GtkBox" id="hbox20">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="spacing">24</property>
                                                 <child>
                                                   <object class="GtkBox" id="vbox16">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="orientation">vertical</property>
                                                     <child>
                                                       <object class="GtkSpinButton" id="spinbuttonlargeurprev">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">True</property>
-                                                        <property name="has_tooltip">True</property>
-                                                        <property name="tooltip_text" translatable="yes">The larger resolution - the longer it takes to generate preview.</property>
-                                                        <property name="max_length">4</property>
-                                                        <property name="invisible_char">•</property>
-                                                        <property name="width_chars">6</property>
-                                                        <property name="primary_icon_activatable">False</property>
-                                                        <property name="secondary_icon_activatable">False</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="has-tooltip">True</property>
+                                                        <property name="tooltip-text" translatable="yes">The larger resolution - the longer it takes to generate preview.</property>
+                                                        <property name="max-length">4</property>
+                                                        <property name="invisible-char">•</property>
+                                                        <property name="width-chars">6</property>
+                                                        <property name="primary-icon-activatable">False</property>
+                                                        <property name="secondary-icon-activatable">False</property>
                                                         <property name="adjustment">adjustment17</property>
-                                                        <property name="climb_rate">1</property>
+                                                        <property name="climb-rate">1</property>
                                                         <property name="numeric">True</property>
                                                       </object>
                                                       <packing>
@@ -1577,8 +1866,8 @@ or contrast weighing, where OPERATOR is one of
                                                     <child>
                                                       <object class="GtkLabel" id="label30">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
-                                                        <property name="margin_top">2</property>
+                                                        <property name="can-focus">False</property>
+                                                        <property name="margin-top">2</property>
                                                         <property name="label" translatable="yes">Width</property>
                                                       </object>
                                                       <packing>
@@ -1597,21 +1886,21 @@ or contrast weighing, where OPERATOR is one of
                                                 <child>
                                                   <object class="GtkBox" id="vbox17">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="orientation">vertical</property>
                                                     <child>
                                                       <object class="GtkSpinButton" id="spinbuttonhauteurprev">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">True</property>
-                                                        <property name="has_tooltip">True</property>
-                                                        <property name="tooltip_text" translatable="yes">The larger resolution - the longer it takes to generate preview.</property>
-                                                        <property name="max_length">4</property>
-                                                        <property name="invisible_char">•</property>
-                                                        <property name="width_chars">6</property>
-                                                        <property name="primary_icon_activatable">False</property>
-                                                        <property name="secondary_icon_activatable">False</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="has-tooltip">True</property>
+                                                        <property name="tooltip-text" translatable="yes">The larger resolution - the longer it takes to generate preview.</property>
+                                                        <property name="max-length">4</property>
+                                                        <property name="invisible-char">•</property>
+                                                        <property name="width-chars">6</property>
+                                                        <property name="primary-icon-activatable">False</property>
+                                                        <property name="secondary-icon-activatable">False</property>
                                                         <property name="adjustment">adjustment18</property>
-                                                        <property name="climb_rate">1</property>
+                                                        <property name="climb-rate">1</property>
                                                         <property name="numeric">True</property>
                                                       </object>
                                                       <packing>
@@ -1623,8 +1912,8 @@ or contrast weighing, where OPERATOR is one of
                                                     <child>
                                                       <object class="GtkLabel" id="label31">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
-                                                        <property name="margin_top">2</property>
+                                                        <property name="can-focus">False</property>
+                                                        <property name="margin-top">2</property>
                                                         <property name="label" translatable="yes">Height</property>
                                                       </object>
                                                       <packing>
@@ -1644,7 +1933,7 @@ or contrast weighing, where OPERATOR is one of
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">False</property>
-                                                <property name="pack_type">end</property>
+                                                <property name="pack-type">end</property>
                                                 <property name="position">1</property>
                                               </packing>
                                             </child>
@@ -1676,7 +1965,7 @@ or contrast weighing, where OPERATOR is one of
                                         <child>
                                           <object class="GtkHSeparator" id="hseparator6">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -1687,14 +1976,14 @@ or contrast weighing, where OPERATOR is one of
                                         <child>
                                           <object class="GtkBox" id="hbox11">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="margin_left">4</property>
-                                            <property name="margin_right">4</property>
-                                            <property name="margin_top">4</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="margin-left">4</property>
+                                            <property name="margin-right">4</property>
+                                            <property name="margin-top">4</property>
                                             <child>
                                               <object class="GtkLabel" id="label18">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Final image size:</property>
                                                 <property name="xalign">0</property>
                                               </object>
@@ -1707,19 +1996,19 @@ or contrast weighing, where OPERATOR is one of
                                             <child>
                                               <object class="GtkCheckButton" id="checkbuttonfinalsize">
                                                 <property name="label" translatable="yes">Default</property>
-                                                <property name="use_action_appearance">False</property>
+                                                <property name="use-action-appearance">False</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="receives_default">False</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="receives-default">False</property>
                                                 <property name="xalign">0.5</property>
                                                 <property name="active">True</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">False</property>
                                                 <property name="padding">6</property>
-                                                <property name="pack_type">end</property>
+                                                <property name="pack-type">end</property>
                                                 <property name="position">1</property>
                                               </packing>
                                             </child>
@@ -1733,23 +2022,23 @@ or contrast weighing, where OPERATOR is one of
                                         <child>
                                           <object class="GtkBox" id="hbox10">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="margin_left">4</property>
-                                            <property name="margin_right">4</property>
-                                            <property name="margin_bottom">4</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="margin-left">4</property>
+                                            <property name="margin-right">4</property>
+                                            <property name="margin-bottom">4</property>
                                             <property name="spacing">1</property>
                                             <child>
                                               <object class="GtkBox" id="vbox9">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="orientation">vertical</property>
                                                 <child>
                                                   <object class="GtkSpinButton" id="spinbuttonfinalwidth">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="invisible_char">•</property>
-                                                    <property name="primary_icon_activatable">False</property>
-                                                    <property name="secondary_icon_activatable">False</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="invisible-char">•</property>
+                                                    <property name="primary-icon-activatable">False</property>
+                                                    <property name="secondary-icon-activatable">False</property>
                                                     <property name="adjustment">adjustment21</property>
                                                     <property name="numeric">True</property>
                                                   </object>
@@ -1762,12 +2051,12 @@ or contrast weighing, where OPERATOR is one of
                                                 <child>
                                                   <object class="GtkLabel" id="label19">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="halign">start</property>
-                                                    <property name="margin_left">5</property>
-                                                    <property name="margin_top">2</property>
+                                                    <property name="margin-left">5</property>
+                                                    <property name="margin-top">2</property>
                                                     <property name="label" translatable="yes">Width</property>
-                                                    <property name="track_visited_links">False</property>
+                                                    <property name="track-visited-links">False</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
@@ -1785,15 +2074,15 @@ or contrast weighing, where OPERATOR is one of
                                             <child>
                                               <object class="GtkBox" id="vbox10">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="orientation">vertical</property>
                                                 <child>
                                                   <object class="GtkSpinButton" id="spinbuttonfinalheight">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="invisible_char">•</property>
-                                                    <property name="primary_icon_activatable">False</property>
-                                                    <property name="secondary_icon_activatable">False</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="invisible-char">•</property>
+                                                    <property name="primary-icon-activatable">False</property>
+                                                    <property name="secondary-icon-activatable">False</property>
                                                     <property name="adjustment">adjustment22</property>
                                                     <property name="numeric">True</property>
                                                   </object>
@@ -1806,12 +2095,12 @@ or contrast weighing, where OPERATOR is one of
                                                 <child>
                                                   <object class="GtkLabel" id="label20">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="halign">start</property>
-                                                    <property name="margin_left">5</property>
-                                                    <property name="margin_top">2</property>
+                                                    <property name="margin-left">5</property>
+                                                    <property name="margin-top">2</property>
                                                     <property name="label" translatable="yes">Height</property>
-                                                    <property name="track_visited_links">False</property>
+                                                    <property name="track-visited-links">False</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
@@ -1829,15 +2118,15 @@ or contrast weighing, where OPERATOR is one of
                                             <child>
                                               <object class="GtkBox" id="vbox13">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="orientation">vertical</property>
                                                 <child>
                                                   <object class="GtkSpinButton" id="spinbuttonxoff">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="invisible_char">•</property>
-                                                    <property name="primary_icon_activatable">False</property>
-                                                    <property name="secondary_icon_activatable">False</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="invisible-char">•</property>
+                                                    <property name="primary-icon-activatable">False</property>
+                                                    <property name="secondary-icon-activatable">False</property>
                                                     <property name="adjustment">adjustment23</property>
                                                     <property name="numeric">True</property>
                                                   </object>
@@ -1850,12 +2139,12 @@ or contrast weighing, where OPERATOR is one of
                                                 <child>
                                                   <object class="GtkLabel" id="label22">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="halign">start</property>
-                                                    <property name="margin_left">5</property>
-                                                    <property name="margin_top">2</property>
+                                                    <property name="margin-left">5</property>
+                                                    <property name="margin-top">2</property>
                                                     <property name="label" translatable="yes">X-offset</property>
-                                                    <property name="track_visited_links">False</property>
+                                                    <property name="track-visited-links">False</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
@@ -1873,15 +2162,15 @@ or contrast weighing, where OPERATOR is one of
                                             <child>
                                               <object class="GtkBox" id="vbox11">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="orientation">vertical</property>
                                                 <child>
                                                   <object class="GtkSpinButton" id="spinbuttonyoff">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="invisible_char">•</property>
-                                                    <property name="primary_icon_activatable">False</property>
-                                                    <property name="secondary_icon_activatable">False</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="invisible-char">•</property>
+                                                    <property name="primary-icon-activatable">False</property>
+                                                    <property name="secondary-icon-activatable">False</property>
                                                     <property name="adjustment">adjustment24</property>
                                                     <property name="numeric">True</property>
                                                   </object>
@@ -1894,12 +2183,12 @@ or contrast weighing, where OPERATOR is one of
                                                 <child>
                                                   <object class="GtkLabel" id="label21">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="halign">start</property>
-                                                    <property name="margin_left">5</property>
-                                                    <property name="margin_top">2</property>
+                                                    <property name="margin-left">5</property>
+                                                    <property name="margin-top">2</property>
                                                     <property name="label" translatable="yes">Y-offset</property>
-                                                    <property name="track_visited_links">False</property>
+                                                    <property name="track-visited-links">False</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
@@ -1924,7 +2213,7 @@ or contrast weighing, where OPERATOR is one of
                                         <child>
                                           <object class="GtkHSeparator" id="hseparator10">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -1935,12 +2224,12 @@ or contrast weighing, where OPERATOR is one of
                                         <child>
                                           <object class="GtkBox" id="hbox18">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="border_width">4</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="border-width">4</property>
                                             <child>
                                               <object class="GtkLabel" id="label5">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Jpeg quality: </property>
                                               </object>
                                               <packing>
@@ -1952,13 +2241,13 @@ or contrast weighing, where OPERATOR is one of
                                             <child>
                                               <object class="GtkCheckButton" id="checkbuttonjpegorig">
                                                 <property name="label" translatable="yes">Default</property>
-                                                <property name="use_action_appearance">False</property>
+                                                <property name="use-action-appearance">False</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="receives_default">False</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="receives-default">False</property>
                                                 <property name="xalign">0.5</property>
                                                 <property name="active">True</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -1969,17 +2258,17 @@ or contrast weighing, where OPERATOR is one of
                                             <child>
                                               <object class="GtkSpinButton" id="hscalecomprjpeg">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="max_length">100</property>
-                                                <property name="width_chars">3</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="max-length">100</property>
+                                                <property name="width-chars">3</property>
                                                 <property name="adjustment">adjustment26</property>
-                                                <property name="climb_rate">1</property>
+                                                <property name="climb-rate">1</property>
                                                 <property name="value">100</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="pack_type">end</property>
+                                                <property name="pack-type">end</property>
                                                 <property name="position">2</property>
                                               </packing>
                                             </child>
@@ -1993,7 +2282,7 @@ or contrast weighing, where OPERATOR is one of
                                         <child>
                                           <object class="GtkHSeparator" id="hseparator11">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2004,12 +2293,12 @@ or contrast weighing, where OPERATOR is one of
                                         <child>
                                           <object class="GtkBox" id="hbox19">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="border_width">4</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="border-width">4</property>
                                             <child>
                                               <object class="GtkLabel" id="label9">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Tiff compression: </property>
                                               </object>
                                               <packing>
@@ -2021,7 +2310,7 @@ or contrast weighing, where OPERATOR is one of
                                             <child>
                                               <object class="GtkComboBox" id="combtiff">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="model">model2</property>
                                                 <property name="active">0</property>
                                                 <child>
@@ -2034,7 +2323,7 @@ or contrast weighing, where OPERATOR is one of
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="pack_type">end</property>
+                                                <property name="pack-type">end</property>
                                                 <property name="position">1</property>
                                               </packing>
                                             </child>
@@ -2048,7 +2337,7 @@ or contrast weighing, where OPERATOR is one of
                                         <child>
                                           <object class="GtkHSeparator" id="hseparator_e_10">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2059,12 +2348,12 @@ or contrast weighing, where OPERATOR is one of
                                         <child>
                                           <object class="GtkBox" id="hbox_e_19">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="border_width">4</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="border-width">4</property>
                                             <child>
                                               <object class="GtkLabel" id="label_e_9">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Edit with: </property>
                                               </object>
                                               <packing>
@@ -2076,24 +2365,24 @@ or contrast weighing, where OPERATOR is one of
                                             <child>
                                               <object class="GtkEntry" id="entry_editor">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">True</property>
-                                                <property name="tooltip_text">
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="tooltip-text">
 Enter name of graphics editor to edit images
 (f.e. gimp (default), fotoxx, delaboratory)                                        
                                         </property>
-                                                <property name="width_chars">24</property>
+                                                <property name="width-chars">24</property>
                                                 <property name="text">gimp</property>
-                                                <property name="caps_lock_warning">False</property>
-                                                <property name="secondary_icon_stock">gtk-apply</property>
-                                                <property name="primary_icon_activatable">False</property>
-                                                <property name="primary_icon_sensitive">False</property>
+                                                <property name="caps-lock-warning">False</property>
+                                                <property name="secondary-icon-stock">gtk-apply</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="primary-icon-sensitive">False</property>
                                                 <signal name="activate" handler="on_entry_editor_activate" swapped="no"/>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="pack_type">end</property>
+                                                <property name="pack-type">end</property>
                                                 <property name="position">1</property>
                                               </packing>
                                             </child>
@@ -2107,19 +2396,19 @@ Enter name of graphics editor to edit images
                                         <child>
                                           <object class="GtkBox" id="box3">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="spacing">1</property>
                                             <child>
                                               <object class="GtkCheckButton" id="checkbuttonexif">
                                                 <property name="label" translatable="yes">Copy exif info ?</property>
-                                                <property name="use_action_appearance">False</property>
+                                                <property name="use-action-appearance">False</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="margin_top">4</property>
-                                                <property name="margin_bottom">4</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="margin-top">4</property>
+                                                <property name="margin-bottom">4</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">True</property>
@@ -2130,14 +2419,14 @@ Enter name of graphics editor to edit images
                                             <child>
                                               <object class="GtkCheckButton" id="checkbuttonalignfiles">
                                                 <property name="label" translatable="yes">Create aligned files in folder?</property>
-                                                <property name="use_action_appearance">False</property>
+                                                <property name="use-action-appearance">False</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="margin_top">4</property>
-                                                <property name="margin_bottom">4</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="margin-top">4</property>
+                                                <property name="margin-bottom">4</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">True</property>
@@ -2165,9 +2454,9 @@ Enter name of graphics editor to edit images
                                 <child type="label">
                                   <object class="GtkLabel" id="label28">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">&lt;b&gt;Software Options&lt;/b&gt;</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                   </object>
                                 </child>
                               </object>
@@ -2185,12 +2474,12 @@ Enter name of graphics editor to edit images
                         <child type="tab">
                           <object class="GtkLabel" id="label4">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Save Options</property>
                           </object>
                           <packing>
                             <property name="position">2</property>
-                            <property name="tab_fill">False</property>
+                            <property name="tab-fill">False</property>
                           </packing>
                         </child>
                       </object>
@@ -2204,17 +2493,17 @@ Enter name of graphics editor to edit images
                     <child>
                       <object class="GtkButtonBox" id="hbuttonbox1">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_right">4</property>
-                        <property name="layout_style">end</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-right">4</property>
+                        <property name="layout-style">end</property>
                         <child>
                           <object class="GtkButton" id="buttonbeforeafter">
                             <property name="label" translatable="yes">_Before/After</property>
-                            <property name="use_action_appearance">False</property>
+                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="pressed" handler="on_buttonbeforeafter_pressed" swapped="no"/>
                             <signal name="released" handler="on_buttonbeforeafter_released" swapped="no"/>
                             <accelerator key="b" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
@@ -2228,11 +2517,11 @@ Enter name of graphics editor to edit images
                         <child>
                           <object class="GtkButton" id="buttonpreview">
                             <property name="label" translatable="yes">_Preview</property>
-                            <property name="use_action_appearance">False</property>
+                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="clicked" handler="on_buttonpreview_clicked" swapped="no"/>
                             <accelerator key="p" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
                           </object>
@@ -2253,59 +2542,59 @@ Enter name of graphics editor to edit images
                     <child>
                       <object class="GtkFrame" id="frame11">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="border_width">4</property>
-                        <property name="label_xalign">1</property>
+                        <property name="can-focus">False</property>
+                        <property name="border-width">4</property>
+                        <property name="label-xalign">1</property>
                         <child>
                           <object class="GtkButtonBox" id="hbuttonbox11">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_bottom">4</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-bottom">4</property>
                             <property name="spacing">2</property>
-                            <property name="layout_style">center</property>
+                            <property name="layout-style">center</property>
                             <child>
                               <object class="GtkButton" id="buttonabout">
                                 <property name="label">gtk-about</property>
-                                <property name="use_action_appearance">False</property>
+                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="use_stock">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="use-stock">True</property>
                                 <signal name="clicked" handler="on_buttonabout_clicked" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="position">0</property>
-                                <property name="non_homogeneous">True</property>
+                                <property name="non-homogeneous">True</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="buttoncancel">
                                 <property name="label">gtk-quit</property>
-                                <property name="use_action_appearance">False</property>
+                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="use_stock">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="use-stock">True</property>
                                 <signal name="clicked" handler="on_buttoncancel_clicked" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
                                 <property name="position">3</property>
-                                <property name="non_homogeneous">True</property>
+                                <property name="non-homogeneous">True</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="buttoneditw">
                                 <property name="label">gtk-edit</property>
-                                <property name="use_action_appearance">False</property>
+                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="use_underline">True</property>
-                                <property name="use_stock">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="use-underline">True</property>
+                                <property name="use-stock">True</property>
                                 <signal name="clicked" handler="on_buttoneditw_clicked" swapped="no"/>
                                 <accelerator key="e" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
                               </object>
@@ -2313,18 +2602,18 @@ Enter name of graphics editor to edit images
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
                                 <property name="position">4</property>
-                                <property name="non_homogeneous">True</property>
+                                <property name="non-homogeneous">True</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="buttonfusion">
                                 <property name="label">gtk-save</property>
-                                <property name="use_action_appearance">False</property>
+                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="use_underline">True</property>
-                                <property name="use_stock">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="use-underline">True</property>
+                                <property name="use-stock">True</property>
                                 <signal name="clicked" handler="on_buttonfusion_clicked" swapped="no"/>
                                 <accelerator key="s" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
                               </object>
@@ -2332,7 +2621,7 @@ Enter name of graphics editor to edit images
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
                                 <property name="position">5</property>
-                                <property name="non_homogeneous">True</property>
+                                <property name="non-homogeneous">True</property>
                               </packing>
                             </child>
                           </object>
@@ -2340,9 +2629,9 @@ Enter name of graphics editor to edit images
                         <child type="label">
                           <object class="GtkLabel" id="Action">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Action&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -2350,7 +2639,7 @@ Enter name of graphics editor to edit images
                         <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="padding">1</property>
-                        <property name="pack_type">end</property>
+                        <property name="pack-type">end</property>
                         <property name="position">2</property>
                       </packing>
                     </child>
@@ -2371,25 +2660,25 @@ Enter name of graphics editor to edit images
             <child>
               <object class="GtkBox" id="vbox7">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkFrame" id="frame2">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="resize_mode">immediate</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="can-focus">False</property>
+                    <property name="resize-mode">immediate</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
                     <child>
                       <object class="GtkAlignment" id="alignment2">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="resize_mode">immediate</property>
+                        <property name="can-focus">False</property>
+                        <property name="resize-mode">immediate</property>
                         <child>
                           <object class="GtkImage" id="imagepreview">
-                            <property name="width_request">1024</property>
+                            <property name="width-request">1024</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="stock">gtk-missing-image</property>
                           </object>
                         </child>
@@ -2398,10 +2687,10 @@ Enter name of graphics editor to edit images
                     <child type="label">
                       <object class="GtkLabel" id="label2">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_top">4</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-top">4</property>
                         <property name="label" translatable="yes">&lt;b&gt;Preview&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                     </child>
                   </object>
@@ -2414,7 +2703,7 @@ Enter name of graphics editor to edit images
                 <child>
                   <object class="GtkProgressBar" id="progressbar">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -2425,12 +2714,12 @@ Enter name of graphics editor to edit images
                 <child>
                   <object class="GtkStatusbar" id="status1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="pack_type">end</property>
+                    <property name="pack-type">end</property>
                     <property name="position">1</property>
                   </packing>
                 </child>

--- a/ui/ui.xml
+++ b/ui/ui.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkAdjustment" id="adjustment1">
@@ -105,12 +105,6 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
-  <object class="GtkHScale" id="hscalecomprjpeg">
-    <property name="visible">True</property>
-    <property name="can_focus">True</property>
-    <property name="adjustment">adjustment25</property>
-    <property name="digits">0</property>
-  </object>
   <object class="GtkAdjustment" id="adjustment26">
     <property name="upper">100</property>
     <property name="step_increment">1</property>
@@ -203,6 +197,9 @@
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <signal name="destroy" handler="on_mainwindow_destroy" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
@@ -1186,6 +1183,8 @@ radius of the Gaussian used in the search for edges.
                                               <object class="GtkLabel" id="label24">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="margin_left">5</property>
                                                 <property name="margin_top">4</property>
                                                 <property name="label" translatable="yes">EdgeScale</property>
                                               </object>
@@ -1262,6 +1261,8 @@ factor (“strength”).
                                               <object class="GtkLabel" id="label25">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="margin_left">5</property>
                                                 <property name="margin_top">4</property>
                                                 <property name="label" translatable="yes">LceScale</property>
                                               </object>
@@ -1334,6 +1335,8 @@ LCE-FACTOR is the weight factor (“strength”)
                                               <object class="GtkLabel" id="label26">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="margin_left">5</property>
                                                 <property name="margin_top">4</property>
                                                 <property name="label" translatable="yes">LceFactor</property>
                                               </object>
@@ -1532,6 +1535,7 @@ or contrast weighing, where OPERATOR is one of
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Preview size:</property>
+                                                <property name="ellipsize">middle</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -1555,11 +1559,14 @@ or contrast weighing, where OPERATOR is one of
                                                         <property name="can_focus">True</property>
                                                         <property name="has_tooltip">True</property>
                                                         <property name="tooltip_text" translatable="yes">The larger resolution - the longer it takes to generate preview.</property>
+                                                        <property name="max_length">4</property>
                                                         <property name="invisible_char">•</property>
+                                                        <property name="width_chars">6</property>
                                                         <property name="primary_icon_activatable">False</property>
                                                         <property name="secondary_icon_activatable">False</property>
                                                         <property name="adjustment">adjustment17</property>
-                                                        <property name="climb_rate">0.029999999999999999</property>
+                                                        <property name="climb_rate">1</property>
+                                                        <property name="numeric">True</property>
                                                       </object>
                                                       <packing>
                                                         <property name="expand">False</property>
@@ -1598,11 +1605,14 @@ or contrast weighing, where OPERATOR is one of
                                                         <property name="can_focus">True</property>
                                                         <property name="has_tooltip">True</property>
                                                         <property name="tooltip_text" translatable="yes">The larger resolution - the longer it takes to generate preview.</property>
+                                                        <property name="max_length">4</property>
                                                         <property name="invisible_char">•</property>
+                                                        <property name="width_chars">6</property>
                                                         <property name="primary_icon_activatable">False</property>
                                                         <property name="secondary_icon_activatable">False</property>
                                                         <property name="adjustment">adjustment18</property>
-                                                        <property name="climb_rate">0.029999999999999999</property>
+                                                        <property name="climb_rate">1</property>
+                                                        <property name="numeric">True</property>
                                                       </object>
                                                       <packing>
                                                         <property name="expand">False</property>
@@ -1646,154 +1656,22 @@ or contrast weighing, where OPERATOR is one of
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkHSeparator" id="hseparator8">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
+                                          <placeholder/>
                                         </child>
                                         <child>
-                                          <object class="GtkLabel" id="label23">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="margin_left">4</property>
-                                            <property name="margin_right">4</property>
-                                            <property name="margin_top">4</property>
-                                            <property name="label" translatable="yes">Cache Size:</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">2</property>
-                                          </packing>
+                                          <placeholder/>
                                         </child>
                                         <child>
-                                          <object class="GtkBox" id="hbox12">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="margin_left">4</property>
-                                            <property name="margin_right">4</property>
-                                            <property name="margin_bottom">4</property>
-                                            <child>
-                                              <object class="GtkCheckButton" id="checkbuttoncache">
-                                                <property name="label" translatable="yes">1024 Mb (default)</property>
-                                                <property name="use_action_appearance">False</property>
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="xalign">0.5</property>
-                                                <property name="active">True</property>
-                                                <property name="draw_indicator">True</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">True</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spinbuttoncache">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="invisible_char">•</property>
-                                                <property name="primary_icon_activatable">False</property>
-                                                <property name="secondary_icon_activatable">False</property>
-                                                <property name="adjustment">adjustment19</property>
-                                                <property name="value">1024</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="pack_type">end</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">3</property>
-                                          </packing>
+                                          <placeholder/>
                                         </child>
                                         <child>
-                                          <object class="GtkHSeparator" id="hseparator3">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">4</property>
-                                          </packing>
+                                          <placeholder/>
                                         </child>
                                         <child>
-                                          <object class="GtkLabel" id="label17">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="margin_left">4</property>
-                                            <property name="margin_right">4</property>
-                                            <property name="margin_top">4</property>
-                                            <property name="label" translatable="yes">Bloc Size: </property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">5</property>
-                                          </packing>
+                                          <placeholder/>
                                         </child>
                                         <child>
-                                          <object class="GtkBox" id="hbox9">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="margin_left">4</property>
-                                            <property name="margin_right">4</property>
-                                            <property name="margin_bottom">4</property>
-                                            <child>
-                                              <object class="GtkCheckButton" id="checkbuttonbloc">
-                                                <property name="label" translatable="yes">2048 kb (default)</property>
-                                                <property name="use_action_appearance">False</property>
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="xalign">0.5</property>
-                                                <property name="active">True</property>
-                                                <property name="draw_indicator">True</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">True</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spinbuttonbloc">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="invisible_char">•</property>
-                                                <property name="primary_icon_activatable">False</property>
-                                                <property name="secondary_icon_activatable">False</property>
-                                                <property name="adjustment">adjustment20</property>
-                                                <property name="value">2048</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="pack_type">end</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">6</property>
-                                          </packing>
+                                          <placeholder/>
                                         </child>
                                         <child>
                                           <object class="GtkHSeparator" id="hseparator6">
@@ -1885,8 +1763,11 @@ or contrast weighing, where OPERATOR is one of
                                                   <object class="GtkLabel" id="label19">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
+                                                    <property name="halign">start</property>
+                                                    <property name="margin_left">5</property>
                                                     <property name="margin_top">2</property>
                                                     <property name="label" translatable="yes">Width</property>
+                                                    <property name="track_visited_links">False</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
@@ -1926,8 +1807,11 @@ or contrast weighing, where OPERATOR is one of
                                                   <object class="GtkLabel" id="label20">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
+                                                    <property name="halign">start</property>
+                                                    <property name="margin_left">5</property>
                                                     <property name="margin_top">2</property>
                                                     <property name="label" translatable="yes">Height</property>
+                                                    <property name="track_visited_links">False</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
@@ -1967,8 +1851,11 @@ or contrast weighing, where OPERATOR is one of
                                                   <object class="GtkLabel" id="label22">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
+                                                    <property name="halign">start</property>
+                                                    <property name="margin_left">5</property>
                                                     <property name="margin_top">2</property>
                                                     <property name="label" translatable="yes">X-offset</property>
+                                                    <property name="track_visited_links">False</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
@@ -2008,8 +1895,11 @@ or contrast weighing, where OPERATOR is one of
                                                   <object class="GtkLabel" id="label21">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
+                                                    <property name="halign">start</property>
+                                                    <property name="margin_left">5</property>
                                                     <property name="margin_top">2</property>
                                                     <property name="label" translatable="yes">Y-offset</property>
+                                                    <property name="track_visited_links">False</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
@@ -2077,7 +1967,7 @@ or contrast weighing, where OPERATOR is one of
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkSpinButton" id="hscalecomprjpg">
+                                              <object class="GtkSpinButton" id="hscalecomprjpeg">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="max_length">100</property>
@@ -2256,15 +2146,7 @@ Enter name of graphics editor to edit images
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkSeparator" id="separator1">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">2</property>
-                                              </packing>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -2304,7 +2186,7 @@ Enter name of graphics editor to edit images
                           <object class="GtkLabel" id="label4">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Configuration</property>
+                            <property name="label" translatable="yes">Save Options</property>
                           </object>
                           <packing>
                             <property name="position">2</property>


### PR DESCRIPTION
Another change was that the commandline arguments for the image CACHESIZE (-m) and the image cache BLOCKSIZE (-b) were removed, but these fields are still in the GUI. Those fields are useless now and need to removed in a GUI re-design attempt.